### PR TITLE
Fixing and Adding features to LeaderKey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Updates/*
 *xcuserdata*
+.DS_STORE

--- a/Leader Key/AppDelegate.swift
+++ b/Leader Key/AppDelegate.swift
@@ -47,6 +47,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     statusItem.handlePreferences = {
       self.settingsWindowController.show()
+      NSApp.activate(ignoringOtherApps: true)
     }
     statusItem.handleReloadConfig = {
       self.config.reloadConfig()
@@ -71,7 +72,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
   @IBAction
   func settingsMenuItemActionHandler(_: NSMenuItem) {
-    settingsWindowController.show()
+    self.settingsWindowController.show()
+    NSApp.activate(ignoringOtherApps: true)
   }
 
   func show() {

--- a/Leader Key/AppDelegate.swift
+++ b/Leader Key/AppDelegate.swift
@@ -21,7 +21,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       Settings.Pane(
         identifier: .general, title: "General",
         toolbarIcon: NSImage(named: NSImage.preferencesGeneralName)!,
-        contentView: { GeneralPane().environmentObject(self.config) }
+        contentView: { 
+          GeneralPane()
+            .environmentObject(self.config)
+            .environmentObject(self.state)
+        }
       )
     ]
   )

--- a/Leader Key/AppDelegate.swift
+++ b/Leader Key/AppDelegate.swift
@@ -63,6 +63,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       if self.window.isVisible && self.window.isKeyWindow {
         self.hide()
       } else {
+        self.state.hideOptions()  // Changed from userState to state
         self.show()
       }
     }

--- a/Leader Key/Controller.swift
+++ b/Leader Key/Controller.swift
@@ -38,8 +38,16 @@ class Controller {
 
   func keyDown(with event: NSEvent) {
     switch event.keyCode {
-    case KeyHelpers.Backspace.rawValue: clear()
-    case KeyHelpers.Escape.rawValue: hide()
+    case KeyHelpers.Backspace.rawValue:
+      if !userState.popGroup() {
+        // At root level, only clear if we have a display value
+        if userState.display != nil {
+          clear()
+        }
+      }
+      userState.hideOptions()
+    case KeyHelpers.Escape.rawValue:
+      hide()
     default:
       let char = event.charactersIgnoringModifiers?.lowercased()
 
@@ -66,8 +74,7 @@ class Controller {
         hide()
       case let .group(group):
         userState.hideOptions()
-        userState.display = group.key
-        userState.currentGroup = group
+        userState.pushGroup(group)  // Changed from direct assignment to pushGroup
       case .none:
         window.shake()
         userState.showOptions = true

--- a/Leader Key/Controller.swift
+++ b/Leader Key/Controller.swift
@@ -61,13 +61,16 @@ class Controller {
 
       switch hit {
       case let .action(action):
+        userState.hideOptions()
         runAction(action)
         hide()
       case let .group(group):
+        userState.hideOptions()
         userState.display = group.key
         userState.currentGroup = group
       case .none:
         window.shake()
+        userState.showOptions = true
       }
     }
   }

--- a/Leader Key/GeneralPane.swift
+++ b/Leader Key/GeneralPane.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct GeneralPane: View {
   private let contentWidth = 600.0
   @EnvironmentObject private var config: UserConfig
+  @EnvironmentObject private var userState: UserState
 
   var body: some View {
     Settings.Container(contentWidth: contentWidth) {
@@ -39,6 +40,22 @@ struct GeneralPane: View {
             }
           }
         }
+      }
+
+      Settings.Section(title: "Cheatsheet") {
+        HStack {
+          
+          Picker("Config Display Mode", selection: $userState.optionsDisplayMode) { // Added label parameter
+            ForEach(OptionsDisplayMode.allCases, id: \.self) { mode in
+              Text(mode.rawValue).tag(mode)
+            }
+          }
+          .frame(width: 129)
+          .labelsHidden() // Hide the label since we're using our own Text view
+          .onChange(of: userState.optionsDisplayMode) { _ in
+            userState.updateOptionsVisibility()
+          }
+                  }
       }
 
       Settings.Section(title: "Shortcut") {

--- a/Leader Key/UserState.swift
+++ b/Leader Key/UserState.swift
@@ -1,11 +1,18 @@
 import SwiftUI
 
+enum OptionsDisplayMode: String, CaseIterable {
+    case never = "Never show"
+    case afterDelay = "After delay"
+    case always = "Always show"
+}
+
 final class UserState: ObservableObject {
   var userConfig: UserConfig!
 
   @Published var display: String?
   @Published var currentGroup: Group?
   @Published var showOptions = true
+  @Published var optionsDisplayMode: OptionsDisplayMode = .afterDelay
   private var showOptionsTimer: Timer?
 
   init(userConfig: UserConfig!, lastChar: String? = nil, currentGroup: Group? = nil) {
@@ -13,9 +20,11 @@ final class UserState: ObservableObject {
     display = lastChar
     self.currentGroup = currentGroup
     self.showOptions = false  // Start with options hidden
+    updateOptionsVisibility()
   }
 
   func hideOptions() {
+    guard optionsDisplayMode == .afterDelay else { return }
     showOptions = false
     showOptionsTimer?.invalidate()
     showOptionsTimer = Timer.scheduledTimer(withTimeInterval: 1.5, repeats: false) { [weak self] _ in
@@ -23,10 +32,23 @@ final class UserState: ObservableObject {
     }
   }
 
+  func updateOptionsVisibility() {
+    switch optionsDisplayMode {
+    case .never:
+      showOptions = false
+      showOptionsTimer?.invalidate()
+    case .always:
+      showOptions = true
+      showOptionsTimer?.invalidate()
+    case .afterDelay:
+      showOptions = true
+    }
+  }
+
   func clear() {
     display = nil
     currentGroup = userConfig.root
-    showOptions = true
+    updateOptionsVisibility()
     showOptionsTimer?.invalidate()
   }
 }

--- a/Leader Key/UserState.swift
+++ b/Leader Key/UserState.swift
@@ -5,15 +5,28 @@ final class UserState: ObservableObject {
 
   @Published var display: String?
   @Published var currentGroup: Group?
+  @Published var showOptions = true
+  private var showOptionsTimer: Timer?
 
   init(userConfig: UserConfig!, lastChar: String? = nil, currentGroup: Group? = nil) {
     self.userConfig = userConfig
     display = lastChar
     self.currentGroup = currentGroup
+    self.showOptions = false  // Start with options hidden
+  }
+
+  func hideOptions() {
+    showOptions = false
+    showOptionsTimer?.invalidate()
+    showOptionsTimer = Timer.scheduledTimer(withTimeInterval: 1.5, repeats: false) { [weak self] _ in
+      self?.showOptions = true
+    }
   }
 
   func clear() {
     display = nil
     currentGroup = userConfig.root
+    showOptions = true
+    showOptionsTimer?.invalidate()
   }
 }

--- a/Leader Key/UserState.swift
+++ b/Leader Key/UserState.swift
@@ -14,6 +14,7 @@ final class UserState: ObservableObject {
   @Published var showOptions = true
   @Published var optionsDisplayMode: OptionsDisplayMode = .afterDelay
   private var showOptionsTimer: Timer?
+  private var groupHistory: [Group] = []  // Add this line
 
   init(userConfig: UserConfig!, lastChar: String? = nil, currentGroup: Group? = nil) {
     self.userConfig = userConfig
@@ -45,9 +46,27 @@ final class UserState: ObservableObject {
     }
   }
 
+  func pushGroup(_ group: Group) {
+    if let currentGroup = currentGroup {
+      groupHistory.append(currentGroup)
+    }
+    currentGroup = group
+    display = group.key
+  }
+
+  func popGroup() -> Bool {
+    guard !groupHistory.isEmpty else {
+      return false  // At root level
+    }
+    currentGroup = groupHistory.removeLast()
+    display = currentGroup?.key
+    return true
+  }
+
   func clear() {
     display = nil
-    currentGroup = userConfig.root
+    currentGroup = nil
+    groupHistory.removeAll()
     updateOptionsVisibility()
     showOptionsTimer?.invalidate()
   }

--- a/Leader Key/Views/ConfigEditorView.swift
+++ b/Leader Key/Views/ConfigEditorView.swift
@@ -39,10 +39,11 @@ struct GroupContentView: View {
         AddButtons(
           onAddAction: {
             group.actions.append(
-              .action(Action(key: "", type: .application, value: "")))
+              .action(Action(key: "", type: .application, value: "", friendly: ""))
+            )
           },
           onAddGroup: {
-            group.actions.append(.group(Group(key: "", actions: [])))
+            group.actions.append(.group(Group(key: "", friendly: "", actions: [])))
           }
         )
       }.padding(.top, PADDING * 0.5)
@@ -86,7 +87,7 @@ struct ActionOrGroupRow: View {
     Binding(
       get: {
         if case .action(let action) = item { return action }
-        return Action(key: "", type: .application, value: "")
+          return Action(key: "", type: .application, value: "", friendly: "")
       },
       set: { item = .action($0) }
     )
@@ -111,6 +112,10 @@ struct ActionRow: View {
     HStack(spacing: PADDING) {
       TextField("Key", text: $action.key)
         .frame(width: 32)
+        .textFieldStyle(.roundedBorder)
+
+      TextField("Friendly", text: $action.friendly)
+        .frame(width: 100)
         .textFieldStyle(.roundedBorder)
 
       Picker("Type", selection: $action.type) {
@@ -163,6 +168,13 @@ struct GroupRow: View {
         .frame(width: 32)
         .textFieldStyle(.roundedBorder)
 
+        TextField("Friendly", text: Binding(
+          get: { group.friendly ?? "" },
+          set: { group.friendly = $0 }
+        ))
+        .frame(width: 100)
+        .textFieldStyle(.roundedBorder)
+
         Image(systemName: "chevron.right")
           .rotationEffect(.degrees(isExpanded ? 90 : 0))
           .onTapGesture {
@@ -201,47 +213,55 @@ struct GroupRow: View {
   let group = Group(actions: [
     // Level 1 actions
     .action(
-      Action(key: "t", type: .application, value: "/Applications/WezTerm.app")),
+      Action(key: "t", type: .application, value: "/Applications/WezTerm.app", friendly: "WezTerm")),
     .action(
-      Action(key: "f", type: .application, value: "/Applications/Firefox.app")),
+      Action(key: "f", type: .application, value: "/Applications/Firefox.app", friendly: "Firefox")),
 
     // Level 1 group with actions
     .group(
       Group(
         key: "b",
+        friendly: "Browsers",
         actions: [
           .action(
             Action(
               key: "c", type: .application,
-              value: "/Applications/Google Chrome.app")),
+              value: "/Applications/Google Chrome.app",
+              friendly: "Chrome")),
           .action(
             Action(
-              key: "s", type: .application, value: "/Applications/Safari.app")),
+              key: "s", type: .application, 
+              value: "/Applications/Safari.app",
+              friendly: "Safari")),
         ])),
 
     // Level 1 group with subgroups
     .group(
       Group(
         key: "r",
+        friendly: "Raycast",
         actions: [
           .action(
             Action(
               key: "e", type: .url,
-              value:
-                "raycast://extensions/raycast/emoji-symbols/search-emoji-symbols"
+              value: "raycast://extensions/raycast/emoji-symbols/search-emoji-symbols",
+              friendly: "Emoji"
             )),
           .group(
             Group(
               key: "w",
+              friendly: "Window Management",
               actions: [
                 .action(
                   Action(
                     key: "f", type: .url,
-                    value: "raycast://window-management/maximize")),
+                    value: "raycast://window-management/maximize",
+                    friendly: "Maximize")),
                 .action(
                   Action(
                     key: "h", type: .url,
-                    value: "raycast://window-management/left-half")),
+                    value: "raycast://window-management/left-half",
+                    friendly: "Left Half")),
               ])),
         ])),
   ])

--- a/Leader Key/Views/MainView.swift
+++ b/Leader Key/Views/MainView.swift
@@ -9,17 +9,83 @@ import SwiftUI
 
 struct MainView: View {
   @EnvironmentObject var userState: UserState
+  
+  func truncatedValue(_ value: String) -> String {
+    if value.count <= 20 { return value }
+    let prefix = String(value.prefix(10))
+    let suffix = String(value.suffix(10))
+    return "\(prefix)...\(suffix)"
+  }
+  
+  var currentOptions: [(key: String, displayText: String?, fullValue: String?)] {
+    let actions = (userState.currentGroup ?? userState.userConfig.root).actions
+    return actions.compactMap { item -> (String, String?, String?)? in
+      switch item {
+      case .action(let action):
+        if action.friendly.isEmpty {
+          return (action.key, truncatedValue(action.value), action.value)
+        } else {
+          return (action.key, action.friendly, nil)
+        }
+      case .group(let group):
+        // Show friendly name for groups if it exists
+        if let friendly = group.friendly, !friendly.isEmpty {
+          return (group.key ?? "", friendly, nil)
+        }
+        return (group.key ?? "", nil, nil)
+      }
+    }
+  }
+
+  // Pre-compute options view
+  private var optionsView: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      ForEach(currentOptions, id: \.key) { option in
+        HStack(spacing: 4) {
+          Text(option.key)
+            .fontWeight(.medium)
+          if let displayText = option.displayText {
+            Text("→")
+              .foregroundColor(.secondary)
+            Text(displayText)
+              .foregroundColor(.secondary)
+          }
+        }
+        .font(.system(size: 14, design: .rounded))
+      }
+    }
+    .padding(.top, 8)
+  }
 
   var body: some View {
     VStack(spacing: 8) {
-      Text(userState.currentGroup?.key ?? userState.display ?? "●").fontDesign(.rounded).fontWeight(
-        .semibold
-      ).font(.system(size: 28, weight: .semibold, design: .rounded))
-    }.frame(width: 200, height: 200, alignment: .center)
-      .background(
+      // Main symbol/key display
+      Text(userState.currentGroup?.key ?? userState.display ?? "●")
+        .fontDesign(.rounded)
+        .fontWeight(.semibold)
+        .font(.system(size: 28, weight: .semibold, design: .rounded))
+      
+      if let friendly = userState.currentGroup?.friendly, !friendly.isEmpty {
+        Text("(\(friendly))")
+          .fontDesign(.rounded)
+          .fontWeight(.regular)
+          .font(.system(size: 16))
+          .foregroundColor(.secondary)
+      }
+      
+      if userState.showOptions {
+        optionsView
+      }
+    }
+    .frame(width: 250)
+    .frame(minHeight: 250)  // Set minimum height
+    .background(
+      GeometryReader { proxy in
         VisualEffectView(material: .hudWindow, blendingMode: .behindWindow)
-      )
-      .clipShape(RoundedRectangle(cornerRadius: 25.0, style: .continuous))
+          .frame(height: proxy.size.height)
+      }
+    )
+    .clipShape(RoundedRectangle(cornerRadius: 25.0, style: .continuous))
   }
 }
 

--- a/Leader Key/Window.swift
+++ b/Leader Key/Window.swift
@@ -7,7 +7,7 @@ class Window: NSPanel, NSWindowDelegate {
   override var canBecomeKey: Bool { return true }
   override var canBecomeMain: Bool { return true }
 
-  var controller: Controller
+  weak var controller: Controller?
 
   init(controller: Controller) {
     self.controller = controller
@@ -24,7 +24,7 @@ class Window: NSPanel, NSWindowDelegate {
 
     center()
 
-    let view = MainView().environmentObject(self.controller.userState)
+    let view = MainView().environmentObject(self.controller!.userState)
     contentView = NSHostingView(rootView: view)
 
     backgroundColor = .clear
@@ -44,7 +44,12 @@ class Window: NSPanel, NSWindowDelegate {
   }
 
   override func keyDown(with event: NSEvent) {
-    controller.keyDown(with: event)
+    controller?.keyDown(with: event)
+  }
+
+  override func resignKey() {
+    super.resignKey()
+    controller?.hide()
   }
 
   func show() {


### PR DESCRIPTION
This PR implements the following changes:
1. Auto-dismissal of popup when focus is lost (fixes #19)
2. Addition of friendly names visible in the cheatsheet (fixes #3)
3. [NEW] Using backspace traverses back in navigation history
4. Cheatsheet activation with 3 options (never show, always show, show with delay) (fixes #12 and fixes #6)
5. New edit menu based on [this suggestion](https://github.com/mikker/LeaderKey.app/issues/13#issuecomment-2612484971) (fixes #13)
6. Fixed preferences window not appearing in front when previously opened (fixes #17)

Note: I'm haven't ever coded in Swift or used XCode, but I've tested the code and everything appears to work correctly. This is a manual AI conversation based contribution (not an AI-agent driven PR). I just like testing LLM limits, while contributing to codebases I like.

AI use disclosure and conversations: https://gist.github.com/nerdymomocat/3673e367fc32549622fbb1cf79a6f473