### PR TITLE
Modified application selection dialog

### DIFF
--- a/Leader Key/Views/ConfigEditorView.swift
+++ b/Leader Key/Views/ConfigEditorView.swift
@@ -124,11 +124,12 @@ struct ActionRow: View {
 
       if action.type == .application {
         Button("Choose...") {
-          let panel = NSOpenPanel()
-          panel.allowsMultipleSelection = false
-          panel.canChooseDirectories = false
-          panel.canChooseFiles = true
-          panel.allowedContentTypes = [.application]
+            let panel = NSOpenPanel()
+            panel.allowedContentTypes = [.applicationBundle, .application]
+            panel.canChooseFiles = true
+            panel.canChooseDirectories = true
+            panel.allowsMultipleSelection = false
+            panel.directoryURL = URL(fileURLWithPath: "/Applications")
 
           if panel.runModal() == .OK {
             action.value = panel.url?.path ?? ""

--- a/Leader Key/Views/ConfigEditorView.swift
+++ b/Leader Key/Views/ConfigEditorView.swift
@@ -124,12 +124,12 @@ struct ActionRow: View {
 
       if action.type == .application {
         Button("Choose...") {
-            let panel = NSOpenPanel()
-            panel.allowedContentTypes = [.applicationBundle, .application]
-            panel.canChooseFiles = true
-            panel.canChooseDirectories = true
-            panel.allowsMultipleSelection = false
-            panel.directoryURL = URL(fileURLWithPath: "/Applications")
+          let panel = NSOpenPanel()
+          panel.allowedContentTypes = [.applicationBundle, .application]
+          panel.canChooseFiles = true
+          panel.canChooseDirectories = true
+          panel.allowsMultipleSelection = false
+          panel.directoryURL = URL(fileURLWithPath: "/Applications")
 
           if panel.runModal() == .OK {
             action.value = panel.url?.path ?? ""
@@ -141,6 +141,7 @@ struct ActionRow: View {
           panel.allowsMultipleSelection = false
           panel.canChooseDirectories = true
           panel.canChooseFiles = false
+          panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser
 
           if panel.runModal() == .OK {
             action.value = panel.url?.path ?? ""


### PR DESCRIPTION
To make it a little more comfortable to select an application, i defaulted the `NSOpenPanel` to the `/Applications` dir

Also in the case of the folder button, I defaulted its path to the `$HOME` directory