### PR TITLE
Enable case-sensitivity

### DIFF
--- a/Leader Key/Cheatsheet.swift
+++ b/Leader Key/Cheatsheet.swift
@@ -12,7 +12,7 @@ enum Cheatsheet {
     let key: String
 
     var body: some SwiftUI.View {
-      Text(key.uppercased())
+      Text(key)
         .font(.system(.body, design: .rounded))
         .multilineTextAlignment(.center)
         .fontWeight(.bold)

--- a/Leader Key/Controller.swift
+++ b/Leader Key/Controller.swift
@@ -60,7 +60,7 @@ class Controller {
     case KeyHelpers.Escape.rawValue:
       hide()
     default:
-      let char = event.charactersIgnoringModifiers?.lowercased()
+      let char = event.charactersIgnoringModifiers
 
       if char == "?" {
         showCheatsheet()
@@ -74,11 +74,11 @@ class Controller {
       let hit = list?.actions.first { item in
         switch item {
         case let .group(group):
-          if group.key?.lowercased() == char {
+          if group.key == char {
             return true
           }
         case let .action(action):
-          if action.key?.lowercased() == char {
+          if action.key == char {
             return true
           }
         }


### PR DESCRIPTION
To be able to use case-sensitivity I removed `lowercased` and `uppercased` modifications for key checks and in the cheatsheet. 
This fixes https://github.com/mikker/LeaderKey.app/issues/52

<div align=center>
<video  alt="" src="https://github.com/user-attachments/assets/e384a15f-a677-40ae-a3eb-aeca0a7af343"/>
</div>


