### PR TITLE
force english layout

### DIFF
--- a/Leader Key/Controller.swift
+++ b/Leader Key/Controller.swift
@@ -14,6 +14,16 @@ class Controller {
   var userState: UserState
   var userConfig: UserConfig
 
+  // Key map for English characters based on US QWERTY keyboard layout
+  let englishKeyMap: [UInt16: String] = [
+    // Letters a-z (verified)
+    0x00: "a", 0x0B: "b", 0x08: "c", 0x02: "d", 0x0E: "e", 0x03: "f",
+    0x05: "g", 0x04: "h", 0x22: "i", 0x26: "j", 0x28: "k", 0x25: "l",
+    0x2E: "m", 0x2D: "n", 0x1F: "o", 0x23: "p", 0x0C: "q", 0x0F: "r",
+    0x01: "s", 0x11: "t", 0x20: "u", 0x09: "v", 0x0D: "w", 0x07: "x",
+    0x10: "y", 0x06: "z",
+  ]
+
   var window: Window!
   var cheatsheetWindow: NSWindow?
 
@@ -60,7 +70,14 @@ class Controller {
     case KeyHelpers.Escape.rawValue:
       hide()
     default:
-      let char = event.charactersIgnoringModifiers
+      // Map key code to English character, ignoring the current input layout
+      let keyCode = event.keyCode
+      var char = (UserDefaults.standard.bool(forKey: "useEnglishKeyMap") ? englishKeyMap[keyCode] : event.charactersIgnoringModifiers) ?? event.charactersIgnoringModifiers ?? ""
+
+      // Check if Shift is pressed and convert to uppercase if needed
+      if event.modifierFlags.contains(.shift) {
+        char = char.uppercased()
+      }
 
       if char == "?" {
         showCheatsheet()

--- a/Leader Key/Defaults.swift
+++ b/Leader Key/Defaults.swift
@@ -6,4 +6,6 @@ extension Defaults.Keys {
   static let watchConfigFile = Key<Bool>("watchConfigFile", default: false)
   static let configDir = Key<String>("configDir", default: CONFIG_DIR_EMPTY)
   static let showMenuBarIcon = Key<Bool>("showInMenubar", default: true)
+  static let useEnglishKeyMap = Key<Bool>("useEnglishKeyMap", default: true)
+
 }

--- a/Leader Key/GeneralPane.swift
+++ b/Leader Key/GeneralPane.swift
@@ -74,6 +74,7 @@ struct GeneralPane: View {
       Settings.Section(title: "App") {
         LaunchAtLogin.Toggle()
         Defaults.Toggle("Show Leader Key in menubar", key: .showMenuBarIcon)
+        Defaults.Toggle("Force English QWERTY keyboard layout", key: .useEnglishKeyMap)
       }
     }
   }


### PR DESCRIPTION
Adds a toggle in the settings: “Force English QWERTY keyboard layout.”

This helps users with multiple keyboard layouts. Currently, if a non-English layout is active when triggering LeaderKey, it processes keys based on the active layout’s language. While this might be useful to some users, most users find it more helpful to “assume English” when entering keys into LeaderKey. This allows them to configure one set of rules with English letters and use those rules regardless of the current input language.

The new setting toggle makes LeaderKey ignore the active input layout and use the English character corresponding to the keycode. This effectively makes LeaderKey language-agnostic, allowing users to trigger the configured letter regardless of the active keyboard layout.