### PR TITLE
Show group header only if group key is not nil

### DIFF
--- a/Leader Key/Views/Cheatsheet.swift
+++ b/Leader Key/Views/Cheatsheet.swift
@@ -126,7 +126,7 @@ enum Cheatsheet {
     var body: some SwiftUI.View {
       ScrollView {
         SwiftUI.VStack(alignment: .leading, spacing: 4) {
-          if let group = userState.currentGroup {
+          if let group = userState.currentGroup, group.key != nil {
             HStack {
               KeyBadge(key: group.key ?? "")
               Text(group.displayName)


### PR DESCRIPTION
The `Cheatsheet` header always displayed a header. This PR is a suggestion to not display the header if the group key is `nil`. The group key should always be `nil` at the root.

| Before | After |
| ------ | ----- |
| <img width="626" alt="before in root" src="https://github.com/user-attachments/assets/0170b8b7-233c-4986-aa96-0405209081cd" /> | <img width="626" alt="after in root" src="https://github.com/user-attachments/assets/f00d703f-c986-4ea4-b016-98622d34ec3b" /> |
| <img width="626" alt="before in group" src="https://github.com/user-attachments/assets/eee1e845-38ff-4c46-a19f-9633eb2ecaab" /> | <img width="626" alt="after in group" src="https://github.com/user-attachments/assets/53d4601e-56ad-41e2-a45a-8a1469261509" /> |

