### PR TITLE
New feature: Group sequence modifier key

### DIFF
--- a/Leader Key/AdvancedPane.swift
+++ b/Leader Key/AdvancedPane.swift
@@ -13,11 +13,14 @@ struct AdvancedPane: View {
 
   var body: some View {
     Settings.Container(contentWidth: contentWidth) {
-      Settings.Section(
-        title: "Config directory",
-        bottomDivider: true
-      ) {
-        HStack {
+    Settings.Section(
+      title: "Config directory",
+      bottomDivider: true
+    ) {
+      HStack () {
+        Text(configDir).lineLimit(1).truncationMode(.middle) 
+      }
+      HStack {
           Button("Choose…") {
             let panel = NSOpenPanel()
             panel.allowsMultipleSelection = false
@@ -27,11 +30,6 @@ struct AdvancedPane: View {
             guard let selectedPath = panel.url else { return }
             configDir = selectedPath.path
           }
-
-          Text(configDir).lineLimit(1).truncationMode(.middle)
-
-          Spacer()
-
           Button("Reveal") {
             NSWorkspace.shared.activateFileViewerSelecting([
               config.fileURL()

--- a/Leader Key/AdvancedPane.swift
+++ b/Leader Key/AdvancedPane.swift
@@ -8,6 +8,8 @@ struct AdvancedPane: View {
   private let contentWidth = 640.0
   @EnvironmentObject private var config: UserConfig
   @Default(.configDir) var configDir
+  @Default(.modifierKeyForGroupSequence) var modifierKeyForGroupSequence
+    
 
   var body: some View {
     Settings.Container(contentWidth: contentWidth) {
@@ -40,6 +42,20 @@ struct AdvancedPane: View {
             configDir = UserConfig.defaultDirectory()
           }
         }
+      }
+        
+      Settings.Section(title: "Group Sequence Modifier Key", bottomDivider: true) {
+        Picker("", selection: $modifierKeyForGroupSequence) {
+            ForEach(ModifierKey.allCases, id: \.self) { key in
+                Text(key.rawValue.capitalized).tag(key)
+          }
+        }
+        .pickerStyle(MenuPickerStyle())
+        Text("If this modifier key is held while pressing a key corresponding to a group, then all actions in that group and its subgroups will be executed sequentially.")
+              .font(.subheadline)
+              .italic()
+        .padding(.leading, 10)
+        .padding(.top, 2)
       }
 
       Settings.Section(title: "Cheatsheet", bottomDivider: true) {

--- a/Leader Key/Controller.swift
+++ b/Leader Key/Controller.swift
@@ -105,8 +105,14 @@ class Controller {
           self.runAction(action)
         }
       case let .group(group):
-        userState.display = group.key
-        userState.currentGroup = group
+        if (shouldRunGroupSequence(event)){
+          hide {
+            self.runGroup(group)
+          }
+        } else {
+          userState.display = group.key
+          userState.currentGroup = group
+        }
       case .none:
         window.shake()
       }
@@ -116,6 +122,14 @@ class Controller {
     delay(1) {
       self.positionCheatsheetWindow()
     }
+  }
+
+  private func shouldRunGroupSequence(_ event: NSEvent) -> Bool{
+    let selectedModifier = Defaults[.modifierKeyForGroupSequence]
+    guard let modifierFlag = selectedModifier.flag else {
+      return false
+    }
+    return event.modifierFlags.contains(modifierFlag)
   }
 
   private func positionCheatsheetWindow() {
@@ -133,6 +147,18 @@ class Controller {
   private func showCheatsheet() {
     positionCheatsheetWindow()
     cheatsheetWindow?.orderFront(nil)
+  }
+
+  private func runGroup(_ group: Group) {
+    group.actions.forEach { groupOrAction in
+      switch groupOrAction
+      {
+        case let .group(group):
+          runGroup(group)
+        case let .action(action):
+          runAction(action)
+      }
+    }
   }
 
   private func runAction(_ action: Action) {

--- a/Leader Key/Defaults.swift
+++ b/Leader Key/Defaults.swift
@@ -1,5 +1,4 @@
 import Defaults
-import AppKit
 
 let CONFIG_DIR_EMPTY = "CONFIG_DIR_EMPTY"
 

--- a/Leader Key/Defaults.swift
+++ b/Leader Key/Defaults.swift
@@ -1,4 +1,5 @@
 import Defaults
+import AppKit
 
 let CONFIG_DIR_EMPTY = "CONFIG_DIR_EMPTY"
 
@@ -10,4 +11,5 @@ extension Defaults.Keys {
 
   static let alwaysShowCheatsheet = Key<Bool>("alwaysShowCheatsheet", default: false)
   static let expandGroupsInCheatsheet = Key<Bool>("expandGroupsInCheatsheet", default: false)
+  static let modifierKeyForGroupSequence = Key<ModifierKey>("modifierKeyForGroupSequence", default: .none)
 }

--- a/Leader Key/UserConfig.swift
+++ b/Leader Key/UserConfig.swift
@@ -257,3 +257,19 @@ enum ActionOrGroup: Codable {
     }
   }
 }
+
+enum ModifierKey: String, Codable, Defaults.Serializable, CaseIterable, Identifiable {
+  case none
+  case control
+  case option
+
+  var id: Self { self }
+
+  var flag: NSEvent.ModifierFlags? {
+    switch self {
+      case .control: return .control
+      case .option:  return .option
+      default:  return nil
+    }
+  }
+}


### PR DESCRIPTION
Enable users to define a custom modifier key that, when pressed simultaneously with a key associated with a group, executes all actions within that group and its subgroups in a sequential manner.

I had to also adjust the UI of the advanced tab a little bit, because the width was causing the Reset button to get cut off. Screenshots of the UI attached below.

A couple of things to note:
1. You can run all actions from the top-most level group by holding the modifier key, or you can execute actions of a particular sub group by first going down the hierarchy and then holding the modifier key at the desired group.
2. This is very helpful for those who have a specific set of actions that need to be performed always: for example, for my webdev projects i can now simply use one key to launch vscode, a browser, terminal, etc. And if i want to launch only vscode, i can simply not press the modifier key and use the shortcut normally.
3. If we add a customizable delay between actions in the future, we can pair this with raycast window management for example to really have control over how things happen.
4. You can disable this feature if you want.
5. Modifier keys such as Fn, Shift, Command and Caps Lock are not allowed to avoid interfering with system level shortcuts and also to allow uppercase/lowercase letters.


Old UI:
<img width="812" alt="image" src="https://github.com/user-attachments/assets/e4b778f9-7e42-493c-accb-02f8ab073b25" />

New UI:
<img width="812" alt="image" src="https://github.com/user-attachments/assets/370ce98c-0651-4af1-a03f-84bac16dc285" />

<img width="812" alt="image" src="https://github.com/user-attachments/assets/31e68a50-aee8-42bc-837f-b2cbfc00c76d" />

