### PR TITLE
Add isShowingRefreshState to UserState for cheatsheet visibility

### DIFF
--- a/Leader Key/AppDelegate.swift
+++ b/Leader Key/AppDelegate.swift
@@ -68,10 +68,11 @@ class AppDelegate: NSObject, NSApplicationDelegate,
 
     config.afterReload = { _ in
       self.state.display = "🔃"
-
+      self.state.isLoading = true
       self.show()
       delay(1000) {
         self.hide()
+        self.state.isLoading = false
       }
     }
 

--- a/Leader Key/AppDelegate.swift
+++ b/Leader Key/AppDelegate.swift
@@ -68,11 +68,11 @@ class AppDelegate: NSObject, NSApplicationDelegate,
 
     config.afterReload = { _ in
       self.state.display = "🔃"
-      self.state.isLoading = true
+      self.state.isShowingRefreshState = true
       self.show()
       delay(1000) {
         self.hide()
-        self.state.isLoading = false
+        self.state.isShowingRefreshState = false
       }
     }
 

--- a/Leader Key/Controller.swift
+++ b/Leader Key/Controller.swift
@@ -27,7 +27,7 @@ class Controller {
   func show() {
     window.show()
 
-    if Defaults[.alwaysShowCheatsheet] && !userState.isLoading {
+    if Defaults[.alwaysShowCheatsheet] && !userState.isShowingRefreshState {
       showCheatsheet()
     }
   }

--- a/Leader Key/Controller.swift
+++ b/Leader Key/Controller.swift
@@ -27,7 +27,7 @@ class Controller {
   func show() {
     window.show()
 
-    if Defaults[.alwaysShowCheatsheet] {
+    if Defaults[.alwaysShowCheatsheet] && !userState.isLoading {
       showCheatsheet()
     }
   }

--- a/Leader Key/UserState.swift
+++ b/Leader Key/UserState.swift
@@ -7,15 +7,18 @@ final class UserState: ObservableObject {
 
   @Published var display: String?
   @Published var currentGroup: Group?
+  @Published var isLoading: Bool
 
-  init(userConfig: UserConfig!, lastChar: String? = nil, currentGroup: Group? = nil) {
+  init(userConfig: UserConfig!, lastChar: String? = nil, currentGroup: Group? = nil, isLoading: Bool = false) {
     self.userConfig = userConfig
     display = lastChar
     self.currentGroup = currentGroup
+    self.isLoading = isLoading
   }
 
   func clear() {
     display = nil
     currentGroup = userConfig.root
+    isLoading = false
   }
 }

--- a/Leader Key/UserState.swift
+++ b/Leader Key/UserState.swift
@@ -7,18 +7,18 @@ final class UserState: ObservableObject {
 
   @Published var display: String?
   @Published var currentGroup: Group?
-  @Published var isLoading: Bool
+  @Published var isShowingRefreshState: Bool
 
-  init(userConfig: UserConfig!, lastChar: String? = nil, currentGroup: Group? = nil, isLoading: Bool = false) {
+  init(userConfig: UserConfig!, lastChar: String? = nil, currentGroup: Group? = nil, isShowingRefreshState: Bool = false) {
     self.userConfig = userConfig
     display = lastChar
     self.currentGroup = currentGroup
-    self.isLoading = isLoading
+    self.isShowingRefreshState = isShowingRefreshState
   }
 
   func clear() {
     display = nil
     currentGroup = userConfig.root
-    isLoading = false
+    isShowingRefreshState = false
   }
 }


### PR DESCRIPTION
# Problem
When the "Always show cheatsheet" option is checked and the config is saved to file, the loading icon is visible and so is the cheatsheet.

<div align=center>
<video alt="bug" src="https://github.com/user-attachments/assets/c7138bf8-b086-4da1-8ad8-bb9ff0473cdf" width=400 />
</div>

# Solution

To solve it, I added a `isLoading` state property to `UserState`, that can be used to show the cheatsheet only, when the user state is not in a loading state.

<div align=center>
<video alt="fix" src="https://github.com/user-attachments/assets/53e65a30-ec54-4f80-b84e-7fdc0e6610d5" width=400 />
</div>