### PR TITLE
Add App icon support in cheatsheet if path suffix is .app

### DIFF
--- a/Leader Key/Views/Cheatsheet.swift
+++ b/Leader Key/Views/Cheatsheet.swift
@@ -56,6 +56,10 @@ enum Cheatsheet {
           .foregroundStyle(.secondary)
           .lineLimit(1)
           .truncationMode(.middle)
+        
+        if action.value.hasSuffix(".app") {
+          AppIconImage(appPath: action.value)
+        }
       }
     }
   }
@@ -189,5 +193,48 @@ struct CheatsheetView_Previews: PreviewProvider {
   static var previews: some View {
     Cheatsheet.CheatsheetView()
       .environmentObject(UserState(userConfig: UserConfig()))
+  }
+}
+
+struct AppIconImage: View {
+  let appPath: String
+  let defaultSystemName: String = "questionmark.circle"
+  let size: CGFloat = 32
+
+  var body: some View {
+    let image = if let icon = getAppIcon(path: appPath) {
+      Image(nsImage: icon)
+    } else {
+      Image(systemName: defaultSystemName)
+    }
+    image.resizable()
+      .scaledToFit()
+      .frame(width: size, height: size)
+  }
+  
+  private func getAppIcon(path: String) -> NSImage? {
+    guard FileManager.default.fileExists(atPath: path) else {
+      return nil
+    }
+
+    let icon = NSWorkspace.shared.icon(forFile: path)
+    let resizedIcon = NSImage(size: NSSize(width: size, height: size))
+    resizedIcon.lockFocus()
+    icon.draw(in: NSRect(x: 0, y: 0, width: size, height: size), from: NSRect(x: 0, y: 0, width: icon.size.width, height: icon.size.height), operation: .sourceOver, fraction: 1.0)
+    resizedIcon.unlockFocus()
+    return resizedIcon
+  }
+}
+
+
+struct AppImage_Preview: PreviewProvider {
+  static var previews: some View {
+    let appPaths = ["/Applications/Xcode.app", "/Applications/Safari.app", "/invalid/path"]
+    VStack {
+      ForEach(appPaths, id: \.self) { path in
+        AppIconImage(appPath: path)
+      }
+    }
+    .padding()
   }
 }


### PR DESCRIPTION
Implement app icon display as per proposal https://github.com/mikker/LeaderKey.app/issues/95

**Examples**
|Preview|Cheatsheet|
|-|-|
|![App Image Preview](https://github.com/user-attachments/assets/bc53fd1d-123a-43e5-b710-5acf4562b4a4)|<img width="626" alt="Screenshot 2025-02-08 at 17 32 45" src="https://github.com/user-attachments/assets/cc65d532-24c7-45e1-b92b-1d58c3d4b25d" />|