### PR TITLE
docs: add shortcut info to cheatsheet setting

### DIFF
--- a/Leader Key/AdvancedPane.swift
+++ b/Leader Key/AdvancedPane.swift
@@ -60,7 +60,7 @@ struct AdvancedPane: View {
       }
 
       Settings.Section(title: "Cheatsheet", bottomDivider: true) {
-        Defaults.Toggle("Always show cheatsheet", key: .alwaysShowCheatsheet)
+        Defaults.Toggle("Always show cheatsheet (press `?` to toggle manually)", key: .alwaysShowCheatsheet)
         Defaults.Toggle(
           "Show expanded groups in cheatsheet", key: .expandGroupsInCheatsheet)
         Defaults.Toggle("Show application icons", key: .showAppIconsInCheatsheet)


### PR DESCRIPTION
Had to dig through source code to find how to toggle the cheatsheet manually without showing it always, maybe I just missed the info elsewhere? 🤔 

Anyway I think it's good to just include it next to the setting (or somewhere else (as well))

I'm of course open to tweak the wording