### PR TITLE
Adds setting to hide cheat sheet item details (paths, etc).

### DIFF
--- a/Leader Key/Cheatsheet.swift
+++ b/Leader Key/Cheatsheet.swift
@@ -23,6 +23,7 @@ enum Cheatsheet {
     let action: Action
     let indent: Int
     @Default(.showAppIconsInCheatsheet) var showAppIcons
+    @Default(.showDetailsInCheatsheet) var showDetails
 
     var icon: String {
       switch action.type {
@@ -55,16 +56,19 @@ enum Cheatsheet {
             .truncationMode(.middle)
         }
         Spacer()
-        Text(action.value)
-          .foregroundStyle(.secondary)
-          .lineLimit(1)
-          .truncationMode(.middle)
+        if showDetails {
+          Text(action.value)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .truncationMode(.middle)
+        }
       }
     }
   }
 
   struct GroupRow: SwiftUI.View {
     @Default(.expandGroupsInCheatsheet) var expand
+    @Default(.showDetailsInCheatsheet) var showDetails
     let group: Group
     let indent: Int
 
@@ -80,10 +84,12 @@ enum Cheatsheet {
             .frame(width: iconSize.width, height: iconSize.height, alignment: .center)
           Text(group.displayName)
           Spacer()
-          Text("\(group.actions.count.description) item(s)")
-            .foregroundStyle(.secondary)
-            .lineLimit(1)
-            .truncationMode(.middle)
+          if showDetails {
+            Text("\(group.actions.count.description) item(s)")
+              .foregroundStyle(.secondary)
+              .lineLimit(1)
+              .truncationMode(.middle)
+          }
         }
         if expand {
           ForEach(Array(group.actions.enumerated()), id: \.offset) { _, item in

--- a/Leader Key/Defaults.swift
+++ b/Leader Key/Defaults.swift
@@ -1,4 +1,4 @@
-Defaults.swift timport Cocoa
+import Cocoa
 import Defaults
 
 var defaultsSuite =

--- a/Leader Key/Defaults.swift
+++ b/Leader Key/Defaults.swift
@@ -1,4 +1,4 @@
-import Cocoa
+Defaults.swift timport Cocoa
 import Defaults
 
 var defaultsSuite =
@@ -27,6 +27,8 @@ extension Defaults.Keys {
     "expandGroupsInCheatsheet", default: false, suite: defaultsSuite)
   static let showAppIconsInCheatsheet = Key<Bool>(
     "showAppIconsInCheatsheet", default: true, suite: defaultsSuite)
+  static let showDetailsInCheatsheet = Key<Bool>(
+    "showDetailsInCheatsheet", default: true, suite: defaultsSuite)
 }
 
 enum AutoOpenCheatsheetSetting: String, Defaults.Serializable {

--- a/Leader Key/Settings/AdvancedPane.swift
+++ b/Leader Key/Settings/AdvancedPane.swift
@@ -89,6 +89,9 @@ struct AdvancedPane: View {
           "Show expanded groups in cheatsheet", key: .expandGroupsInCheatsheet)
         Defaults.Toggle(
           "Show application icons", key: .showAppIconsInCheatsheet)
+        Defaults.Toggle(
+          "Show item details in cheatsheet", key: .showDetailsInCheatsheet)
+
       }
 
       Settings.Section(title: "Other") {


### PR DESCRIPTION
This adds a setting to the Cheatsheet section in the Advanced pane. When disabled (default true), it omits the additional details (item's path, URL, or count) for a slightly cleaner look.

## Preview

![setting](https://github.com/user-attachments/assets/622e5542-ccad-4d56-8b7e-3250c55f7785)

![cheatsheet](https://github.com/user-attachments/assets/0d1f8fc5-f41a-4f36-b7ae-e734184dfa42)
