### PR TITLE
Add support for URL scheme

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,21 @@
+# Leader Key Development Guide
+
+## Build & Test Commands
+- Build and run: `xcodebuild -scheme "Leader Key" -configuration Debug build`
+- Run all tests: `xcodebuild -scheme "Leader Key" -testPlan "TestPlan" test`
+- Run single test: `xcodebuild -scheme "Leader Key" -testPlan "TestPlan" -only-testing:Leader KeyTests/UserConfigTests/testInitializesWithDefaults test`
+- Bump version: `bin/bump`
+- Create release: `bin/release`
+
+## Code Style Guidelines
+- **Imports**: Group Foundation/AppKit imports first, then third-party libraries (Combine, Defaults)
+- **Naming**: Use descriptive camelCase for variables/functions, PascalCase for types
+- **Types**: Use explicit type annotations for public properties and parameters
+- **Error Handling**: Use appropriate error handling with do/catch blocks and alerts
+- **Extensions**: Create extensions for additional functionality on existing types
+- **State Management**: Use @Published and ObservableObject for reactive UI updates
+- **Testing**: Create separate test cases with descriptive names, use XCTAssert* methods
+- **Access Control**: Use appropriate access modifiers (private, fileprivate, internal)
+- **Documentation**: Use comments for complex logic or non-obvious implementations
+
+Follow Swift idioms and default formatting (4-space indentation, spaces around operators).

--- a/Leader Key/AppDelegate.swift
+++ b/Leader Key/AppDelegate.swift
@@ -98,7 +98,7 @@ class AppDelegate: NSObject, NSApplicationDelegate,
       }
     }
 
-    KeyboardShortcuts.onKeyUp(for: .activate) {
+    KeyboardShortcuts.onKeyUp(for: .navigate) {
       if self.controller.window.isKeyWindow {
         self.hide()
       } else if self.controller.window.isVisible {
@@ -189,5 +189,53 @@ class AppDelegate: NSObject, NSApplicationDelegate,
     let environment = ProcessInfo.processInfo.environment
     guard environment["XCTestSessionIdentifier"] != nil else { return false }
     return true
+  }
+
+  // MARK: - URL Scheme Handling
+
+  func application(_ application: NSApplication, open urls: [URL]) {
+    for url in urls {
+      handleURL(url)
+    }
+  }
+
+  private func handleURL(_ url: URL) {
+    guard url.scheme == "leaderkey" else { return }
+
+    // Activate the app first
+    show()
+
+    // Parse the URL components
+    if url.host == "navigate",
+      let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+      let queryItems = components.queryItems,
+      let keysParam = queryItems.first(where: { $0.name == "keys" })?.value
+    {
+      // Split the keys by comma and process them
+      let keys = keysParam.split(separator: ",").map(String.init)
+      processKeys(keys)
+    }
+  }
+
+  private func processKeys(_ keys: [String]) {
+    // Ensure we have keys to process
+    guard !keys.isEmpty else { return }
+
+    // Process the first key
+    controller.handleKey(keys[0])
+
+    // If there are more keys, schedule them with a small delay between each
+    if keys.count > 1 {
+      let remainingKeys = Array(keys.dropFirst())
+
+      // Process remaining keys with a slight delay between each
+      var delayMs = 100
+      for key in remainingKeys {
+        delay(delayMs) { [weak self] in
+          self?.controller.handleKey(key)
+        }
+        delayMs += 100
+      }
+    }
   }
 }

--- a/Leader Key/AppDelegate.swift
+++ b/Leader Key/AppDelegate.swift
@@ -202,33 +202,26 @@ class AppDelegate: NSObject, NSApplicationDelegate,
   private func handleURL(_ url: URL) {
     guard url.scheme == "leaderkey" else { return }
 
-    // Activate the app first
     show()
 
-    // Parse the URL components
     if url.host == "navigate",
       let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
       let queryItems = components.queryItems,
       let keysParam = queryItems.first(where: { $0.name == "keys" })?.value
     {
-      // Split the keys by comma and process them
       let keys = keysParam.split(separator: ",").map(String.init)
       processKeys(keys)
     }
   }
 
   private func processKeys(_ keys: [String]) {
-    // Ensure we have keys to process
     guard !keys.isEmpty else { return }
 
-    // Process the first key
     controller.handleKey(keys[0])
 
-    // If there are more keys, schedule them with a small delay between each
     if keys.count > 1 {
       let remainingKeys = Array(keys.dropFirst())
 
-      // Process remaining keys with a slight delay between each
       var delayMs = 100
       for key in remainingKeys {
         delay(delayMs) { [weak self] in

--- a/Leader Key/AppDelegate.swift
+++ b/Leader Key/AppDelegate.swift
@@ -98,7 +98,7 @@ class AppDelegate: NSObject, NSApplicationDelegate,
       }
     }
 
-    KeyboardShortcuts.onKeyUp(for: .navigate) {
+    KeyboardShortcuts.onKeyUp(for: .activate) {
       if self.controller.window.isKeyWindow {
         self.hide()
       } else if self.controller.window.isVisible {

--- a/Leader Key/Constants.swift
+++ b/Leader Key/Constants.swift
@@ -1,7 +1,7 @@
 import KeyboardShortcuts
 
 extension KeyboardShortcuts.Name {
-  static let navigate = Self("navigate")
+  static let activate = Self("navigate")
 }
 
 // Key map for English characters based on US QWERTY keyboard layout

--- a/Leader Key/Constants.swift
+++ b/Leader Key/Constants.swift
@@ -1,7 +1,7 @@
 import KeyboardShortcuts
 
 extension KeyboardShortcuts.Name {
-  static let activate = Self("activate")
+  static let navigate = Self("navigate")
 }
 
 // Key map for English characters based on US QWERTY keyboard layout

--- a/Leader Key/Settings/GeneralPane.swift
+++ b/Leader Key/Settings/GeneralPane.swift
@@ -70,7 +70,7 @@ struct GeneralPane: View {
       }
 
       Settings.Section(title: "Shortcut") {
-        KeyboardShortcuts.Recorder(for: .activate)
+        KeyboardShortcuts.Recorder(for: .navigate)
       }
 
       Settings.Section(title: "Theme") {

--- a/Leader Key/Settings/GeneralPane.swift
+++ b/Leader Key/Settings/GeneralPane.swift
@@ -70,7 +70,7 @@ struct GeneralPane: View {
       }
 
       Settings.Section(title: "Shortcut") {
-        KeyboardShortcuts.Recorder(for: .navigate)
+        KeyboardShortcuts.Recorder(for: .activate)
       }
 
       Settings.Section(title: "Theme") {

--- a/Leader Key/Support/Info.plist
+++ b/Leader Key/Support/Info.plist
@@ -2,6 +2,19 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>com.mikker.leaderkey</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>leaderkey</string>
+			</array>
+		</dict>
+	</array>
 	<key>SUFeedURL</key>
 	<string>https://mikker.github.io/LeaderKey.app/appcast.xml</string>
 	<key>SUPublicEDKey</key>


### PR DESCRIPTION
This adds support for activating and navigating through groups and actions via a custom URL scheme, `leaderkey://navigate?keys=r,p`.

Examples:

- Just activate LK: `leaderkey://`
- Activate, then navigate to the `w` group: `leaderkey://navigate?keys=w`
- Trigger multiple keys by separating them with commas `leaderkey://navigate?keys=r,p`

This also gives users a way to activate LK with multiple different global shortcuts. We could possibly add this as a built it feature at some point but for now, this will let folks do it with BetterTouchTool, Karabiner, Raycast or whatever.

Totally vibed this one with my pal Claude.

---

Closes #117 
Closes #104 (somewhat)
