### PR TITLE
Removed atomic option from write file

### DIFF
--- a/Leader Key/UserConfig.swift
+++ b/Leader Key/UserConfig.swift
@@ -127,7 +127,7 @@ class UserConfig: ObservableObject {
   }
 
   private func writeFile(data: Data) throws {
-    try data.write(to: url, options: [.atomic])
+    try data.write(to: url)
   }
 
   private func readFile() throws -> String {


### PR DESCRIPTION
I removed the .atomic option from writeFile function as it deletes the existing file and creates a new one which if you have a symlink setup gets rid of symlink file and creates a new one.

I know I can direct to a different file but I prefer the symlink so if this is a problem just discard it