### PR TITLE
Ignore second leader key press instead of hiding

### DIFF
--- a/Leader Key/AppDelegate.swift
+++ b/Leader Key/AppDelegate.swift
@@ -100,8 +100,10 @@ class AppDelegate: NSObject, NSApplicationDelegate,
 
     KeyboardShortcuts.onKeyUp(for: .activate) {
       if self.controller.window.isKeyWindow {
-        self.hide()
-      } else if self.controller.window.isVisible {
+        // ignore leader key press when waiting for next key
+        return
+      }
+      if self.controller.window.isVisible {
         // should never happen as the window will self-hide when not key
         self.controller.window.makeKeyAndOrderFront(nil)
       } else {


### PR DESCRIPTION
This is a an "opinionated" pull request. It solves a pain-point I was having with Leader Key.

Sometimes, I will hit the leader key then fat-finger the desired command key resulting in the error "shake". My instinct then is to repeat the command, starting by pressing leader again. Alternatively, I may not be looking at the screen, so I may not be aware the first command failed. In either case, when this happens, the second press of leader key actually dismisses the command window, so then my command key types through to the underlying editor window, which is annoying.

I think if would be better if Leader Key's "contract" with the user is that the leader key press ALWAYS puts it in a state to accept the command key next. Otherwise we have to keep track mentally of what state it is in, which is a higher cognitive load. When we want to dismiss it, we can always press Escape.