### PR TITLE
Minor ui tweaks

### DIFF
--- a/Leader Key/Defaults.swift
+++ b/Leader Key/Defaults.swift
@@ -20,7 +20,7 @@ extension Defaults.Keys {
 
   static let autoOpenCheatsheet = Key<AutoOpenCheatsheetSetting>(
     "autoOpenCheatsheet",
-    default: .delay, suite: defaultsSuite)
+    default: .always, suite: defaultsSuite)
   static let cheatsheetDelayMS = Key<Int>(
     "cheatsheetDelayMS", default: 2000, suite: defaultsSuite)
   static let expandGroupsInCheatsheet = Key<Bool>(

--- a/Leader Key/Settings/AdvancedPane.swift
+++ b/Leader Key/Settings/AdvancedPane.swift
@@ -22,6 +22,13 @@ struct AdvancedPane: View {
       ) {
         HStack {
           Text(configDir).lineLimit(1).truncationMode(.middle)
+          Button {
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+            pasteboard.setString(configDir, forType: .string)
+          } label: {
+            Image(systemName: "clipboard")
+          }
         }
         HStack {
           Button("Choose…") {
@@ -100,6 +107,8 @@ struct AdvancedPane: View {
         Text(
           "The cheatsheet can always be manually shown by \"?\" when Leader Key is activated."
         )
+        .font(.callout)
+        .foregroundColor(.secondary)
         .padding(.vertical, 2)
 
         Defaults.Toggle(

--- a/Leader Key/Settings/GeneralPane.swift
+++ b/Leader Key/Settings/GeneralPane.swift
@@ -71,6 +71,14 @@ struct GeneralPane: View {
 
       Settings.Section(title: "Shortcut") {
         KeyboardShortcuts.Recorder(for: .activate)
+
+        VStack(alignment: .leading, spacing: 8) {
+          Text(
+            "Shortcut to trigger Leader Key"
+          )
+          .font(.callout)
+          .foregroundColor(.secondary)
+        }
       }
 
       Settings.Section(title: "Theme") {
@@ -79,6 +87,14 @@ struct GeneralPane: View {
           Text("Mini").tag(Theme.mini)
           Text("Breadcrumbs").tag(Theme.breadcrumbs)
         }.frame(maxWidth: 170).labelsHidden()
+
+        VStack(alignment: .leading, spacing: 8) {
+          Text(
+            "Theme configures how Leader Key interface looks when triggered"
+          )
+          .font(.callout)
+          .foregroundColor(.secondary)
+        }
       }
 
       Settings.Section(title: "App") {


### PR DESCRIPTION
Set cheatsheet default to always, copy config dir to clipboard added and some helpers added:

When I first installed the app "Shortcut" and "Theme" wasn't clear at the glance so I thought adding small helpers is nice.

Also for someone who just installed LeaderKey cheatsheet is more essential than later when you develop muscle memory.

And another thing, when I wanted to navigate to config file through terminal I had to either type it by hand or click on reveal and drag it to terminal so I think adding "copy to clipboard" button is nice