### PR TITLE
Add Cheater Theme

### DIFF
--- a/Leader Key.xcodeproj/project.pbxproj
+++ b/Leader Key.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		42F4CDD12D48C52400D0DD76 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42F4CDD02D48C51F00D0DD76 /* Extensions.swift */; };
 		42FDC31A2D51687B004F5C5C /* AdvancedPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42FDC3192D51687B004F5C5C /* AdvancedPane.swift */; };
 		605385A32D523CAD00BEDB4B /* Pulsate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605385A22D523CAD00BEDB4B /* Pulsate.swift */; };
+		606C56EF2DAB875A00198B9F /* Cheater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606C56EE2DAB875A00198B9F /* Cheater.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -100,6 +101,7 @@
 		42F4CDD02D48C51F00D0DD76 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		42FDC3192D51687B004F5C5C /* AdvancedPane.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdvancedPane.swift; sourceTree = "<group>"; };
 		605385A22D523CAD00BEDB4B /* Pulsate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pulsate.swift; sourceTree = "<group>"; };
+		606C56EE2DAB875A00198B9F /* Cheater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cheater.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -132,6 +134,7 @@
 				423632212D68CA6500878D92 /* MysteryBox.swift */,
 				4254953F2D75EFAD0020300E /* ForTheHorde.swift */,
 				423632252D68CDBB00878D92 /* Mini.swift */,
+				606C56EE2DAB875A00198B9F /* Cheater.swift */,
 			);
 			path = Themes;
 			sourceTree = "<group>";
@@ -412,6 +415,7 @@
 				427C18502BD6652500955B98 /* Util.swift in Sources */,
 				427C182A2BD31E2E00955B98 /* StatusItem.swift in Sources */,
 				42F4CDCD2D45B13600D0DD76 /* KeyButton.swift in Sources */,
+				606C56EF2DAB875A00198B9F /* Cheater.swift in Sources */,
 				427C181C2BD314B500955B98 /* Constants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Leader Key/Cheatsheet.swift
+++ b/Leader Key/Cheatsheet.swift
@@ -117,7 +117,7 @@ enum Cheatsheet {
     }
 
     // Constrain to edge of screen
-    var preferredWidth: CGFloat {
+    static var preferredWidth: CGFloat {
       if let screen = NSScreen.main {
         let screenHalf = screen.visibleFrame.width / 2
         let desiredWidth: CGFloat = 580
@@ -165,7 +165,7 @@ enum Cheatsheet {
           }
         )
       }
-      .frame(width: preferredWidth)
+      .frame(width: Cheatsheet.CheatsheetView.preferredWidth)
       .frame(height: min(contentHeight, maxHeight))
       .background(
         VisualEffectView(material: .hudWindow, blendingMode: .behindWindow)

--- a/Leader Key/Controller.swift
+++ b/Leader Key/Controller.swift
@@ -57,11 +57,15 @@ class Controller {
       Events.send(.didActivate)
     }
 
+    if !window.hasCheatsheet || userState.isShowingRefreshState {
+      return
+    }
+
     switch Defaults[.autoOpenCheatsheet] {
     case .always:
-      if !userState.isShowingRefreshState { showCheatsheet() }
+      showCheatsheet()
     case .delay:
-      if !userState.isShowingRefreshState { scheduleCheatsheet() }
+      scheduleCheatsheet()
     default: break
     }
   }

--- a/Leader Key/MainWindow.swift
+++ b/Leader Key/MainWindow.swift
@@ -23,6 +23,7 @@ class MainWindow: PanelWindow, NSWindowDelegate {
   override var canBecomeKey: Bool { return true }
   override var canBecomeMain: Bool { return true }
 
+  var hasCheatsheet: Bool { return true }
   var controller: Controller
 
   required init(controller: Controller) {

--- a/Leader Key/Theme.swift
+++ b/Leader Key/Theme.swift
@@ -5,9 +5,10 @@ enum Theme: String, Defaults.Serializable {
   case mini
   case breadcrumbs
   case forTheHorde
+  case cheater
 
   static var all: [Theme] {
-    return [.mysteryBox, .mini, .breadcrumbs, .forTheHorde]
+    return [.mysteryBox, .mini, .breadcrumbs, .forTheHorde, .cheater]
   }
 
   static func classFor(_ value: Theme) -> MainWindow.Type {
@@ -20,6 +21,8 @@ enum Theme: String, Defaults.Serializable {
       return Breadcrumbs.Window.self
     case .forTheHorde:
       return ForTheHorde.Window.self
+    case .cheater:
+      return Cheater.Window.self
     }
   }
 
@@ -29,6 +32,7 @@ enum Theme: String, Defaults.Serializable {
     case .mini: return "Mini"
     case .breadcrumbs: return "Breadcrumbs"
     case .forTheHorde: return "For The Horde"
+    case .cheater: return "Cheater"
     }
   }
 }

--- a/Leader Key/Themes/Cheater.swift
+++ b/Leader Key/Themes/Cheater.swift
@@ -1,0 +1,29 @@
+import Foundation
+import SwiftUI
+
+enum Cheater {
+  class Window: MainWindow {
+
+    required init(controller: Controller) {
+      super.init(controller: controller, contentRect: NSRect(x: 0, y: 0, width: 0, height: 0))
+      let view = Cheatsheet.CheatsheetView()
+      contentView = NSHostingView(rootView: view.environmentObject(self.controller.userState))
+    }
+
+    override func show(after: (() -> Void)?) {
+      let size = NSScreen.main?.frame.size ?? NSSize()
+      let width = contentView?.frame.width ?? Cheatsheet.CheatsheetView.preferredWidth
+      let height = contentView?.frame.height ?? 0
+      let x = size.width / 2 - width / 2
+      let y = size.height / 2 - height / 2
+      self.setFrame(CGRect(x: x, y: y, width: width, height: height), display: true)
+
+      super.show(after: after)
+    }
+
+    override func cheatsheetOrigin(cheatsheetSize: NSSize) -> NSPoint {
+      // move out of screen
+      return NSPoint(x: -cheatsheetSize.width, y: -cheatsheetSize.height)
+    }
+  }
+}

--- a/Leader Key/Themes/Cheater.swift
+++ b/Leader Key/Themes/Cheater.swift
@@ -4,6 +4,8 @@ import SwiftUI
 enum Cheater {
   class Window: MainWindow {
 
+    override var hasCheatsheet: Bool { return false }
+
     required init(controller: Controller) {
       super.init(controller: controller, contentRect: NSRect(x: 0, y: 0, width: 0, height: 0))
       let view = Cheatsheet.CheatsheetView()
@@ -23,11 +25,6 @@ enum Cheater {
 
     override func notFound() {
       shake()
-    }
-
-    override func cheatsheetOrigin(cheatsheetSize: NSSize) -> NSPoint {
-      // move out of screen
-      return NSPoint(x: -cheatsheetSize.width, y: -cheatsheetSize.height)
     }
   }
 }

--- a/Leader Key/Themes/Cheater.swift
+++ b/Leader Key/Themes/Cheater.swift
@@ -3,7 +3,6 @@ import SwiftUI
 
 enum Cheater {
   class Window: MainWindow {
-
     override var hasCheatsheet: Bool { return false }
 
     required init(controller: Controller) {
@@ -17,7 +16,7 @@ enum Cheater {
       let width = contentView?.frame.width ?? Cheatsheet.CheatsheetView.preferredWidth
       let height = contentView?.frame.height ?? 0
       let x = size.width / 2 - width / 2
-      let y = size.height / 2 - height / 2
+      let y = size.height / 2 - height / 2 + (size.height / 8)
       self.setFrame(CGRect(x: x, y: y, width: width, height: height), display: true)
 
       makeKeyAndOrderFront(nil)

--- a/Leader Key/Themes/Cheater.swift
+++ b/Leader Key/Themes/Cheater.swift
@@ -20,7 +20,18 @@ enum Cheater {
       let y = size.height / 2 - height / 2
       self.setFrame(CGRect(x: x, y: y, width: width, height: height), display: true)
 
-      super.show(after: after)
+      makeKeyAndOrderFront(nil)
+
+      fadeInAndUp {
+        after?()
+      }
+    }
+
+    override func hide(after: (() -> Void)?) {
+      fadeOutAndDown {
+        self.close()
+        after?()
+      }
     }
 
     override func notFound() {

--- a/Leader Key/Themes/Cheater.swift
+++ b/Leader Key/Themes/Cheater.swift
@@ -21,6 +21,10 @@ enum Cheater {
       super.show(after: after)
     }
 
+    override func notFound() {
+      shake()
+    }
+
     override func cheatsheetOrigin(cheatsheetSize: NSSize) -> NSPoint {
       // move out of screen
       return NSPoint(x: -cheatsheetSize.width, y: -cheatsheetSize.height)


### PR DESCRIPTION
Adding a cheater theme to show the cheatsheet at all times. Fixes https://github.com/mikker/LeaderKey.app/issues/112

### Additional info
- Built by reusing `CheatsheetView` as the `MainWindow`
- Added `hasCheatsheet` property to main window that defaults to `true` so every Theme has a cheatsheet by default
- Make `CheatsheetView.preferredWidth` static and reuse for theme