### PR TITLE
Position cheatsheet window on backspace event

### DIFF
--- a/Leader Key/Controller.swift
+++ b/Leader Key/Controller.swift
@@ -111,6 +111,9 @@ class Controller {
     switch event.keyCode {
     case KeyHelpers.backspace.rawValue:
       clear()
+      delay(1) {
+        self.positionCheatsheetWindow()
+      }
     case KeyHelpers.escape.rawValue:
       window.resignKey()
     default:


### PR DESCRIPTION
The cheatsheet was not positioned on the backspace key event. This fixes https://github.com/mikker/LeaderKey.app/issues/174

| Mini | Breadcrumb |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/79cc5a94-a215-45cc-8b4b-440e0d9f1b84"></video> |  <video src="https://github.com/user-attachments/assets/2f619bf8-53f9-4dc8-81c6-b0a4e9409048"> </video> | 

This is more a quickfix and copied the solution from the `handleKey` function.