### PR TITLE
Skip cheatsheet visibility if MainWindow has no cheatsheet

### DIFF
--- a/Leader Key/Controller.swift
+++ b/Leader Key/Controller.swift
@@ -222,6 +222,9 @@ class Controller {
   }
 
   private func showCheatsheet() {
+    if !window.hasCheatsheet {
+      return
+    }
     positionCheatsheetWindow()
     cheatsheetWindow?.orderFront(nil)
   }


### PR DESCRIPTION
Only show cheatsheet if window has cheatsheet. This prevents showing two cheatsheets for themes that include a cheatsheet. Fixes https://github.com/mikker/LeaderKey.app/issues/180