### PR TITLE
Feature: Select screen to show Leader Key on

### DIFF
--- a/Leader Key/Controller.swift
+++ b/Leader Key/Controller.swift
@@ -57,7 +57,8 @@ class Controller {
   func show() {
     Events.send(.willActivate)
 
-    window.show {
+    let screen = Defaults[.screen].getNSScreen() ?? NSScreen()
+    window.show(on: screen) {
       Events.send(.didActivate)
     }
 
@@ -341,5 +342,18 @@ class DontActivateConfiguration {
 
   init() {
     configuration.activates = false
+  }
+}
+
+extension Screen {
+  func getNSScreen() -> NSScreen? {
+    switch self {
+    case .primary:
+      return NSScreen.screens.first
+    case .mouse:
+      return NSScreen.screens.first { $0.frame.contains(NSEvent.mouseLocation) }
+    case .activeWindow:
+      return NSScreen.main
+    }
   }
 }

--- a/Leader Key/Defaults.swift
+++ b/Leader Key/Defaults.swift
@@ -33,6 +33,8 @@ extension Defaults.Keys {
     "showFaviconsInCheatsheet", default: true, suite: defaultsSuite)
   static let reactivateBehavior = Key<ReactivateBehavior>(
     "reactivateBehavior", default: .hide, suite: defaultsSuite)
+  static let screen = Key<Screen>(
+    "screen", default: .primary, suite: defaultsSuite)
 }
 
 enum AutoOpenCheatsheetSetting: String, Defaults.Serializable {
@@ -61,4 +63,10 @@ enum ReactivateBehavior: String, Defaults.Serializable {
   case hide
   case reset
   case nothing
+}
+
+enum Screen: String, Defaults.Serializable {
+  case primary
+  case mouse
+  case activeWindow
 }

--- a/Leader Key/MainWindow.swift
+++ b/Leader Key/MainWindow.swift
@@ -55,7 +55,7 @@ class MainWindow: PanelWindow, NSWindowDelegate {
     controller.keyDown(with: event)
   }
 
-  func show(after: (() -> Void)?) {
+  func show(on screen: NSScreen, after: (() -> Void)?) {
     makeKeyAndOrderFront(nil)
     after?()
   }

--- a/Leader Key/Settings/AdvancedPane.swift
+++ b/Leader Key/Settings/AdvancedPane.swift
@@ -15,6 +15,7 @@ struct AdvancedPane: View {
   @Default(.cheatsheetDelayMS) var cheatsheetDelayMS
   @Default(.reactivateBehavior) var reactivateBehavior
   @Default(.showAppIconsInCheatsheet) var showAppIconsInCheatsheet
+  @Default(.screen) var screen
 
   var body: some View {
     Settings.Container(contentWidth: contentWidth) {
@@ -132,6 +133,16 @@ struct AdvancedPane: View {
           .labelsHidden()
           .frame(width: 220)
         }
+      }
+
+      Settings.Section(title: "Show Leader Key on", bottomDivider: true) {
+        Picker("", selection: $screen) {
+          Text("Screen containing mouse").tag(Screen.mouse)
+          Text("Primary screen").tag(Screen.primary)
+          Text("Screen with active window").tag(Screen.activeWindow)
+        }
+        .labelsHidden()
+        .frame(width: 220)
       }
       Settings.Section(title: "Other") {
         Defaults.Toggle("Show Leader Key in menubar", key: .showMenuBarIcon)

--- a/Leader Key/Themes/Breadcrumbs.swift
+++ b/Leader Key/Themes/Breadcrumbs.swift
@@ -15,9 +15,7 @@ enum Breadcrumbs {
       contentView = NSHostingView(rootView: view)
     }
 
-    override func show(after: (() -> Void)? = nil) {
-      let screen = NSScreen.main == nil ? NSSize() : NSScreen.main!.frame.size
-
+    override func show(on screen: NSScreen, after: (() -> Void)? = nil) {
       if controller.userState.navigationPath.isEmpty == true {
         self.setFrame(
           CGRect(
@@ -38,10 +36,13 @@ enum Breadcrumbs {
         self.contentAspectRatio = NSSize(width: 0, height: Breadcrumbs.dimension)
         self.contentMinSize = NSSize(width: 80, height: Breadcrumbs.dimension)
         self.contentMaxSize = NSSize(
-          width: screen.width - (Breadcrumbs.margin * 2),
+          width: screen.frame.width - (Breadcrumbs.margin * 2),
           height: Breadcrumbs.dimension
         )
       }
+      let newOriginX = screen.frame.origin.x + Breadcrumbs.margin
+      let newOriginY = screen.frame.origin.y + Breadcrumbs.margin
+      self.setFrameOrigin(NSPoint(x: newOriginX, y: newOriginY))
 
       makeKeyAndOrderFront(nil)
 

--- a/Leader Key/Themes/Cheater.swift
+++ b/Leader Key/Themes/Cheater.swift
@@ -11,13 +11,11 @@ enum Cheater {
       contentView = NSHostingView(rootView: view.environmentObject(self.controller.userState))
     }
 
-    override func show(after: (() -> Void)?) {
-      let size = NSScreen.main?.frame.size ?? NSSize()
-      let width = contentView?.frame.width ?? Cheatsheet.CheatsheetView.preferredWidth
-      let height = contentView?.frame.height ?? 0
-      let x = size.width / 2 - width / 2
-      let y = size.height / 2 - height / 2 + (size.height / 8)
-      self.setFrame(CGRect(x: x, y: y, width: width, height: height), display: true)
+    override func show(on screen: NSScreen, after: (() -> Void)?) {
+      let center = screen.center()
+      let newOriginX = center.x - frame.width / 2
+      let newOriginY = center.y - frame.height / 2 + frame.height / 8
+      self.setFrameOrigin(NSPoint(x: newOriginX, y: newOriginY))
 
       makeKeyAndOrderFront(nil)
 

--- a/Leader Key/Themes/ForTheHorde.swift
+++ b/Leader Key/Themes/ForTheHorde.swift
@@ -13,7 +13,6 @@ enum ForTheHorde {
         controller: controller,
         contentRect: NSRect(
           x: 0, y: 0, width: MysteryBox.size, height: MysteryBox.size))
-      center()
 
       backgroundColor = .clear
       isOpaque = false
@@ -25,8 +24,11 @@ enum ForTheHorde {
       contentView = NSHostingView(rootView: view)
     }
 
-    override func show(after: (() -> Void)? = nil) {
-      center()
+    override func show(on screen: NSScreen, after: (() -> Void)? = nil) {
+      let center = screen.center()
+      let newOriginX = center.x - MysteryBox.size / 2
+      let newOriginY = center.y + MysteryBox.size / 8
+      self.setFrameOrigin(NSPoint(x: newOriginX, y: newOriginY))
 
       // Trigger animation by updating the shared state
       animationState.isShowing = true

--- a/Leader Key/Themes/Mini.swift
+++ b/Leader Key/Themes/Mini.swift
@@ -6,22 +6,16 @@ enum Mini {
 
   class Window: MainWindow {
     required init(controller: Controller) {
-      super.init(
-        controller: controller,
-        contentRect: NSRect(x: 0, y: 0, width: 0, height: 0))
-
+      let rect = NSRect(x: 0, y: 0, width: Mini.size, height: Mini.size)
+      super.init(controller: controller, contentRect: rect)
       let view = MainView().environmentObject(self.controller.userState)
       contentView = NSHostingView(rootView: view)
     }
 
-    override func show(after: (() -> Void)? = nil) {
-      let screen = NSScreen.main == nil ? NSSize() : NSScreen.main!.frame.size
-
-      self.setFrame(
-        CGRect(
-          x: screen.width - Mini.size - Mini.margin,
-          y: Mini.margin, width: Mini.size, height: Mini.size),
-        display: true)
+    override func show(on screen: NSScreen, after: (() -> Void)? = nil) {
+      let newOriginX = screen.frame.minX + screen.frame.width - Mini.size - Mini.margin
+      let newOriginY = screen.frame.minY + Mini.margin
+      self.setFrameOrigin(NSPoint(x: newOriginX, y: newOriginY))
 
       makeKeyAndOrderFront(nil)
 

--- a/Leader Key/Themes/MysteryBox.swift
+++ b/Leader Key/Themes/MysteryBox.swift
@@ -8,14 +8,16 @@ enum MysteryBox {
       super.init(
         controller: controller,
         contentRect: NSRect(x: 0, y: 0, width: MysteryBox.size, height: MysteryBox.size))
-      center()
 
       let view = MainView().environmentObject(self.controller.userState)
       contentView = NSHostingView(rootView: view)
     }
 
-    override func show(after: (() -> Void)? = nil) {
-      center()
+    override func show(on screen: NSScreen, after: (() -> Void)? = nil) {
+      let center = screen.center()
+      let newOriginX = center.x - MysteryBox.size / 2
+      let newOriginY = center.y + MysteryBox.size / 8
+      self.setFrameOrigin(NSPoint(x: newOriginX, y: newOriginY))
 
       makeKeyAndOrderFront(nil)
 

--- a/Leader Key/Util.swift
+++ b/Leader Key/Util.swift
@@ -1,5 +1,15 @@
 import Foundation
+import AppKit
 
 func delay(_ milliseconds: Int, callback: @escaping () -> Void) {
   DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(milliseconds), execute: callback)
 }
+
+extension NSScreen {
+  func center() -> NSPoint {
+    let x = frame.origin.x + frame.width / 2
+    let y = frame.origin.y + frame.height / 2
+    return NSPoint(x: x, y: y)
+  }
+}
+


### PR DESCRIPTION
This fixes https://github.com/mikker/LeaderKey.app/issues/30 and https://github.com/mikker/LeaderKey.app/issues/185.

In this PR the option for the screen to "Show Leader Key on" is added.
Followed the selection in Raycast.

| Advanced pane | Selection |
|--------|--------|
| ![advanced-pane](https://github.com/user-attachments/assets/4b5ba42d-387f-4dc4-b74e-b0c1b032745b) | ![selection](https://github.com/user-attachments/assets/dbb6ac32-1d69-4f23-a440-ea3049fe78a7) | 


In addition a bug is fixed where the Cheater theme is misplaced on one screen if multiple screens are used.

No UI changes, only positioning. The positioning of **Mystery Box** and **For The Horde** theme might need to be adjusted. The previous positioning of these themes were calling [NSWindow.center](https://developer.apple.com/documentation/appkit/nswindow/center()) method only in the `show` function.