### PR TITLE
Add direct global shortcuts to 1st level groups

### DIFF
--- a/Leader Key.xcodeproj/project.pbxproj
+++ b/Leader Key.xcodeproj/project.pbxproj
@@ -176,11 +176,11 @@
 		427C17E92BD311B400955B98 /* Leader Key */ = {
 			isa = PBXGroup;
 			children = (
-				42454DDA2D71CB39004E1374 /* ConfigValidator.swift */,
 				42B21FBB2D67566100F4A2C7 /* Alerts.swift */,
 				427C181F2BD31C3D00955B98 /* AppDelegate.swift */,
 				42F4CDCE2D46E2B300D0DD76 /* Cheatsheet.swift */,
 				426E625A2D2E6A98009FD2F2 /* CommandRunner.swift */,
+				42454DDA2D71CB39004E1374 /* ConfigValidator.swift */,
 				427C181B2BD314B500955B98 /* Constants.swift */,
 				427C18272BD31E2E00955B98 /* Controller.swift */,
 				427C184C2BD65C5C00955B98 /* Defaults.swift */,
@@ -188,6 +188,7 @@
 				42F4CDD02D48C51F00D0DD76 /* Extensions.swift */,
 				423632122D676F5200878D92 /* FileMonitor.swift */,
 				42F4CDC82D458FF700D0DD76 /* MainMenu.swift */,
+				427C18252BD31E2E00955B98 /* MainWindow.swift */,
 				427C18532BD6E59300955B98 /* NSWindow+Animations.swift */,
 				427C182C2BD31F9500955B98 /* Settings.swift */,
 				427C18262BD31E2E00955B98 /* StatusItem.swift */,
@@ -195,7 +196,6 @@
 				427C183A2BD329F900955B98 /* UserConfig.swift */,
 				427C182E2BD3206200955B98 /* UserState.swift */,
 				427C184F2BD6652500955B98 /* Util.swift */,
-				427C18252BD31E2E00955B98 /* MainWindow.swift */,
 				427C17EE2BD311B500955B98 /* Assets.xcassets */,
 				423632242D68CC5D00878D92 /* Settings */,
 				427C18362BD3243C00955B98 /* Support */,

--- a/Leader Key/Defaults.swift
+++ b/Leader Key/Defaults.swift
@@ -35,6 +35,10 @@ extension Defaults.Keys {
     "reactivateBehavior", default: .hide, suite: defaultsSuite)
   static let screen = Key<Screen>(
     "screen", default: .primary, suite: defaultsSuite)
+
+  static let groupShortcuts = Key<Set<String>>(
+    "groupShortcuts",
+    default: Set(), suite: defaultsSuite)
 }
 
 enum AutoOpenCheatsheetSetting: String, Defaults.Serializable {

--- a/Leader Key/Util.swift
+++ b/Leader Key/Util.swift
@@ -1,5 +1,5 @@
-import Foundation
 import AppKit
+import Foundation
 
 func delay(_ milliseconds: Int, callback: @escaping () -> Void) {
   DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(milliseconds), execute: callback)
@@ -12,4 +12,3 @@ extension NSScreen {
     return NSPoint(x: x, y: y)
   }
 }
-

--- a/Leader Key/Views/ConfigEditorView.swift
+++ b/Leader Key/Views/ConfigEditorView.swift
@@ -216,7 +216,7 @@ struct ActionRow: View {
           get: { action.key ?? "" },
           set: { action.key = $0 }
         ), placeholder: "Key", validationError: validationErrorForKey,
-        onKeyChanged: { userConfig.finishEditingKey() }
+        onKeyChanged: { _, _ in userConfig.finishEditingKey() }
       )
 
       Picker("Type", selection: $action.type) {
@@ -337,7 +337,13 @@ struct GroupRow: View {
           ),
           placeholder: "Group Key",
           validationError: validationErrorForKey,
-          onKeyChanged: { userConfig.finishEditingKey() }
+          onKeyChanged: { maybePrev, value in
+            if maybePrev != value, let prev = maybePrev {
+              Defaults[.groupShortcuts].remove(prev)
+              KeyboardShortcuts.reset([KeyboardShortcuts.Name("group-\(prev)")])
+            }
+            userConfig.finishEditingKey()
+          }
         )
 
         IconPickerMenu(
@@ -364,7 +370,7 @@ struct GroupRow: View {
             .padding(.horizontal, -3)
         }.buttonStyle(.bordered)
 
-        if let key = group.key {
+        if path.count == 1 && group.key != "", let key = group.key {
           KeyboardShortcuts.Recorder(for: KeyboardShortcuts.Name("group-\(key)")) { shortcut in
             if shortcut != nil {
               Defaults[.groupShortcuts].insert(key)

--- a/Leader Key/Views/ConfigEditorView.swift
+++ b/Leader Key/Views/ConfigEditorView.swift
@@ -1,4 +1,5 @@
 import Defaults
+import KeyboardShortcuts
 import SwiftUI
 import SymbolPicker
 
@@ -360,8 +361,20 @@ struct GroupRow: View {
         ) {
           Image(systemName: "chevron.right")
             .rotationEffect(.degrees(isExpanded ? 90 : 0))
-            .padding(.leading, generalPadding / 3)
-        }.buttonStyle(.plain)
+            .padding(.horizontal, -3)
+        }.buttonStyle(.bordered)
+
+        if let key = group.key {
+          KeyboardShortcuts.Recorder(for: KeyboardShortcuts.Name("group-\(key)")) { shortcut in
+            if shortcut != nil {
+              Defaults[.groupShortcuts].insert(key)
+            } else {
+              Defaults[.groupShortcuts].remove(key)
+            }
+
+            (NSApplication.shared.delegate as! AppDelegate).registerGlobalShortcuts()
+          }
+        }
 
         Spacer(minLength: 0)
 
@@ -478,6 +491,6 @@ struct GroupRow: View {
   let userConfig = UserConfig()
 
   return ConfigEditorView(group: .constant(group), expandedGroups: .constant(Set<[Int]>()))
-    .frame(width: 600, height: 500)
+    .frame(width: 720, height: 500)
     .environmentObject(userConfig)
 }

--- a/Leader Key/Views/KeyButton.swift
+++ b/Leader Key/Views/KeyButton.swift
@@ -1,13 +1,15 @@
 import AppKit
 import SwiftUI
 
+typealias KeyChangedFn = ((_ before: String?, _ value: String?) -> Void)
+
 struct KeyButton: View {
   @Binding var text: String
   let placeholder: String
   @State private var isListening = false
   @State private var oldValue = ""
   var validationError: ValidationErrorType? = nil
-  var onKeyChanged: (() -> Void)? = nil
+  var onKeyChanged: KeyChangedFn? = nil
 
   var body: some View {
     Button(action: {
@@ -57,7 +59,7 @@ struct KeyListenerView: NSViewRepresentable {
   @Binding var isListening: Bool
   @Binding var text: String
   @Binding var oldValue: String
-  var onKeyChanged: (() -> Void)?
+  var onKeyChanged: KeyChangedFn?
 
   func makeNSView(context: Context) -> NSView {
     let view = KeyListenerNSView()
@@ -87,7 +89,7 @@ struct KeyListenerView: NSViewRepresentable {
     var isListening: Binding<Bool>?
     var text: Binding<String>?
     var oldValue: Binding<String>?
-    var onKeyChanged: (() -> Void)?
+    var onKeyChanged: KeyChangedFn?
 
     override var acceptsFirstResponder: Bool { true }
 
@@ -126,7 +128,7 @@ struct KeyListenerView: NSViewRepresentable {
 
       DispatchQueue.main.async {
         isListening.wrappedValue = false
-        self.onKeyChanged?()
+        self.onKeyChanged?(self.oldValue?.wrappedValue, self.text?.wrappedValue)
       }
     }
 
@@ -134,7 +136,7 @@ struct KeyListenerView: NSViewRepresentable {
       if let isListening = isListening, isListening.wrappedValue {
         DispatchQueue.main.async {
           isListening.wrappedValue = false
-          self.onKeyChanged?()
+          self.onKeyChanged?(self.oldValue?.wrappedValue, self.text?.wrappedValue)
         }
       }
       return super.resignFirstResponder()
@@ -151,26 +153,22 @@ struct KeyListenerView: NSViewRepresentable {
       VStack(spacing: 20) {
         KeyButton(
           text: $text,
-          placeholder: "Key",
-          onKeyChanged: { print("Key changed") }
+          placeholder: "Key"
         )
         KeyButton(
           text: $text,
           placeholder: "Key",
-          validationError: .duplicateKey,
-          onKeyChanged: { print("Key changed") }
+          validationError: .duplicateKey
         )
         KeyButton(
           text: $text,
           placeholder: "Key",
-          validationError: .emptyKey,
-          onKeyChanged: { print("Key changed") }
+          validationError: .emptyKey
         )
         KeyButton(
           text: $text,
           placeholder: "Key",
-          validationError: .nonSingleCharacterKey,
-          onKeyChanged: { print("Key changed") }
+          validationError: .nonSingleCharacterKey
         )
         Text("Current value: '\(text)'")
       }


### PR DESCRIPTION
Closes #199, #188, #162

Adds the ability to assign global shortcuts to any 1st level group directly.

![CleanShot 2025-05-06 at 10 34 26@2x](https://github.com/user-attachments/assets/83c5417a-9e1a-4079-9352-d72db329928f)

Honestly feels like a little bit of a mess but it works 😅