### PR TITLE
Position themes based on `visibleFrame` to avoid cutting into dock

### DIFF
--- a/Leader Key/Themes/Breadcrumbs.swift
+++ b/Leader Key/Themes/Breadcrumbs.swift
@@ -40,8 +40,8 @@ enum Breadcrumbs {
           height: Breadcrumbs.dimension
         )
       }
-      let newOriginX = screen.frame.origin.x + Breadcrumbs.margin
-      let newOriginY = screen.frame.origin.y + Breadcrumbs.margin
+      let newOriginX = screen.visibleFrame.origin.x + Breadcrumbs.margin
+      let newOriginY = screen.visibleFrame.origin.y + Breadcrumbs.margin
       self.setFrameOrigin(NSPoint(x: newOriginX, y: newOriginY))
 
       makeKeyAndOrderFront(nil)
@@ -63,7 +63,7 @@ enum Breadcrumbs {
 
     override func cheatsheetOrigin(cheatsheetSize: NSSize) -> NSPoint {
       return NSPoint(
-        x: Breadcrumbs.margin,
+        x: frame.minX,
         y: frame.maxY + Breadcrumbs.margin)
     }
   }

--- a/Leader Key/Themes/Mini.swift
+++ b/Leader Key/Themes/Mini.swift
@@ -13,8 +13,8 @@ enum Mini {
     }
 
     override func show(on screen: NSScreen, after: (() -> Void)? = nil) {
-      let newOriginX = screen.frame.minX + screen.frame.width - Mini.size - Mini.margin
-      let newOriginY = screen.frame.minY + Mini.margin
+      let newOriginX = screen.visibleFrame.maxX - Mini.size - Mini.margin
+      let newOriginY = screen.visibleFrame.minY + Mini.margin
       self.setFrameOrigin(NSPoint(x: newOriginX, y: newOriginY))
 
       makeKeyAndOrderFront(nil)
@@ -35,11 +35,9 @@ enum Mini {
     }
 
     override func cheatsheetOrigin(cheatsheetSize: NSSize) -> NSPoint {
-      let screen = NSScreen.main == nil ? NSSize() : NSScreen.main!.frame.size
-
       return NSPoint(
-        x: screen.width - cheatsheetSize.width - Mini.margin,
-        y: Mini.margin + frame.height + Mini.margin)
+        x: frame.maxX - cheatsheetSize.width,
+        y: frame.maxY + Mini.margin)
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/mikker/LeaderKey.app/issues/149

The `NSScreen.visibleFrame` is used to lay out themes on the screen edges as suggested by @zenangst in https://github.com/mikker/LeaderKey.app/issues/149#issuecomment-2713129852. In addition, the reference to `NSScreen.main` in `cheatsheetOrigin` is replaced by relative positioning to the frame of the theme `MainWindow`.

<details>
<summary>Breadcrumbs theme positioning</summary>

| Dock position | Screenshot |
| ------ | ------ |
| Right | <img width="1000" alt="breadcrumbs-dock-right" src="https://github.com/user-attachments/assets/2aa06ac6-84b0-482d-87be-c160469f8ddb" /> |
| Bottom | <img width="1000" alt="breadcrumbs-dock-bottom" src="https://github.com/user-attachments/assets/dc53dc8e-807d-44ba-aef9-cc4a67e4a15e" /> |
| Left | <img width="1000" alt="breadcrumbs-dock-left" src="https://github.com/user-attachments/assets/0e58f0b8-de02-4e7d-8a1a-caef292c243e" /> | 
</details>

<details>
<summary>Mini theme positioning</summary>

| Dock position | Screenshot |
|--------|--------|
| Right | <img width="1000" alt="mini-dock-right" src="https://github.com/user-attachments/assets/d4f88776-4595-4666-ab43-a9d60a2175fa" /> |
| Bottom | <img width="1000" alt="mini-dock-bottom" src="https://github.com/user-attachments/assets/fc9d7f07-bb0a-40e7-93f1-fad1c3a13cf9" /> |
| Left | <img width="1000" alt="mini-dock-left" src="https://github.com/user-attachments/assets/a59000ef-932c-447e-8b23-3aabfd02f12d" /> | 

</details>