### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*.swift]
+indent_style = space
+indent_size = 2
+insert_final_newline = false
+trim_trailing_whitespace = true


### PR DESCRIPTION
Xcode 16 added support for EditorConfig files. This is a nice way to manage per-project editor settings. Xcode 16 reads .editorconfig files by default, but users can disable EditorConfig support in Xcode's settings if they want.

This project's lint rules expect 2-space indentation. This change adds an initial .editorconfig file that configures the indentation style plus some whitespace settings.