### PR TITLE
[Issue #275] Add catch for when activation shortcut is not set

### DIFF
--- a/Leader Key/AppDelegate.swift
+++ b/Leader Key/AppDelegate.swift
@@ -126,6 +126,9 @@ class AppDelegate: NSObject, NSApplicationDelegate,
         self.processKeys([groupKey])
       }
     }
+    if Defaults[.groupShortcuts].isEmpty && !KeyboardShortcuts.isEnabled(for: .activate) {
+      showSettings()
+    }
   }
 
   func applicationWillTerminate(_ notification: Notification) {


### PR DESCRIPTION
[Issue 275](https://github.com/mikker/LeaderKey.app/issues/275)

This is my best guess of what happened. And since reinstalling and launching again has not visible window, I assumed it wasn't launching.

Further suggestions:
- Maybe always launch the mainWindow at every launch. LaunchKey is usually the first I want to see at login