### PR TITLE
feat: allow hijacking ctrl and opt keys

### DIFF
--- a/Leader Key.xcodeproj/project.pbxproj
+++ b/Leader Key.xcodeproj/project.pbxproj
@@ -15,7 +15,6 @@
 		423632282D6A806700878D92 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 423632272D6A806700878D92 /* Theme.swift */; };
 		42454DDB2D71CB39004E1374 /* ConfigValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42454DDA2D71CB39004E1374 /* ConfigValidator.swift */; };
 		42454DDD2D71CBAB004E1374 /* ConfigValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42454DDC2D71CBAB004E1374 /* ConfigValidatorTests.swift */; };
-		EC5CEBC4C47B4C5DB2258813 /* URLSchemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5CEBC4C47B4C5DB2258814 /* URLSchemeTests.swift */; };
 		425495402D75EFAD0020300E /* ForTheHorde.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4254953F2D75EFAD0020300E /* ForTheHorde.swift */; };
 		426E625B2D2E6A98009FD2F2 /* CommandRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 426E625A2D2E6A98009FD2F2 /* CommandRunner.swift */; };
 		4279AFED2C6A175500952A83 /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = 4279AFEC2C6A175500952A83 /* LaunchAtLogin */; };
@@ -26,7 +25,6 @@
 		427C181A2BD3123C00955B98 /* Defaults in Frameworks */ = {isa = PBXBuildFile; productRef = 427C18192BD3123C00955B98 /* Defaults */; };
 		427C181C2BD314B500955B98 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 427C181B2BD314B500955B98 /* Constants.swift */; };
 		427C18202BD31C3D00955B98 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 427C181F2BD31C3D00955B98 /* AppDelegate.swift */; };
-		73192AF63CAF425397D7C0D1 /* URLSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73192AF63CAF425397D7C0D2 /* URLSchemeHandler.swift */; };
 		427C18232BD31DF100955B98 /* Settings in Frameworks */ = {isa = PBXBuildFile; productRef = 427C18222BD31DF100955B98 /* Settings */; };
 		427C18282BD31E2E00955B98 /* GeneralPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 427C18242BD31E2E00955B98 /* GeneralPane.swift */; };
 		427C18292BD31E2E00955B98 /* MainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 427C18252BD31E2E00955B98 /* MainWindow.swift */; };
@@ -55,6 +53,9 @@
 		6D9B9C012DBA000000000001 /* ConfigOutlineEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D9B9C002DBA000000000001 /* ConfigOutlineEditorView.swift */; };
 		6D9B9C042DBA000000000002 /* KeyCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D9B9C032DBA000000000002 /* KeyCapture.swift */; };
 		6D9B9C062DBA000000000003 /* ConfigEditorShared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D9B9C052DBA000000000003 /* ConfigEditorShared.swift */; };
+		73192AF63CAF425397D7C0D1 /* URLSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73192AF63CAF425397D7C0D2 /* URLSchemeHandler.swift */; };
+		878F1D3B2F16996600BAA500 /* ModifierHijackingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878F1D3A2F16996600BAA500 /* ModifierHijackingTests.swift */; };
+		EC5CEBC4C47B4C5DB2258813 /* URLSchemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5CEBC4C47B4C5DB2258814 /* URLSchemeTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -76,7 +77,6 @@
 		423632272D6A806700878D92 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		42454DDA2D71CB39004E1374 /* ConfigValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigValidator.swift; sourceTree = "<group>"; };
 		42454DDC2D71CBAB004E1374 /* ConfigValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigValidatorTests.swift; sourceTree = "<group>"; };
-		EC5CEBC4C47B4C5DB2258814 /* URLSchemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSchemeTests.swift; sourceTree = "<group>"; };
 		4254953F2D75EFAD0020300E /* ForTheHorde.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForTheHorde.swift; sourceTree = "<group>"; };
 		426E625A2D2E6A98009FD2F2 /* CommandRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandRunner.swift; sourceTree = "<group>"; };
 		4279AFEA2C6A08B100952A83 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = "Leader Key/Support/Info.plist"; sourceTree = SOURCE_ROOT; };
@@ -88,7 +88,6 @@
 		427C17FC2BD311B500955B98 /* UserConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserConfigTests.swift; sourceTree = "<group>"; };
 		427C181B2BD314B500955B98 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		427C181F2BD31C3D00955B98 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		73192AF63CAF425397D7C0D2 /* URLSchemeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSchemeHandler.swift; sourceTree = "<group>"; };
 		427C18242BD31E2E00955B98 /* GeneralPane.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneralPane.swift; sourceTree = "<group>"; };
 		427C18252BD31E2E00955B98 /* MainWindow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainWindow.swift; sourceTree = "<group>"; };
 		427C18262BD31E2E00955B98 /* StatusItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusItem.swift; sourceTree = "<group>"; };
@@ -114,6 +113,9 @@
 		6D9B9C002DBA000000000001 /* ConfigOutlineEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigOutlineEditorView.swift; sourceTree = "<group>"; };
 		6D9B9C032DBA000000000002 /* KeyCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyCapture.swift; sourceTree = "<group>"; };
 		6D9B9C052DBA000000000003 /* ConfigEditorShared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigEditorShared.swift; sourceTree = "<group>"; };
+		73192AF63CAF425397D7C0D2 /* URLSchemeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSchemeHandler.swift; sourceTree = "<group>"; };
+		878F1D3A2F16996600BAA500 /* ModifierHijackingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifierHijackingTests.swift; sourceTree = "<group>"; };
+		EC5CEBC4C47B4C5DB2258814 /* URLSchemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSchemeTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -224,6 +226,7 @@
 		427C17FB2BD311B500955B98 /* Leader KeyTests */ = {
 			isa = PBXGroup;
 			children = (
+				878F1D3A2F16996600BAA500 /* ModifierHijackingTests.swift */,
 				4284834B2E813212009D7EEF /* KeyboardLayoutTests.swift */,
 				42454DDC2D71CBAB004E1374 /* ConfigValidatorTests.swift */,
 				EC5CEBC4C47B4C5DB2258814 /* URLSchemeTests.swift */,
@@ -454,6 +457,7 @@
 				EC5CEBC4C47B4C5DB2258813 /* URLSchemeTests.swift in Sources */,
 				427C17FD2BD311B500955B98 /* UserConfigTests.swift in Sources */,
 				4284834C2E813212009D7EEF /* KeyboardLayoutTests.swift in Sources */,
+				878F1D3B2F16996600BAA500 /* ModifierHijackingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Leader Key/AppDelegate.swift
+++ b/Leader Key/AppDelegate.swift
@@ -20,6 +20,7 @@ class AppDelegate: NSObject, NSApplicationDelegate,
   let config = UserConfig()
 
   var state: UserState!
+  var eventMonitor: Any?
   @IBOutlet var updaterController: SPUStandardUpdaterController!
 
   lazy var settingsWindowController = SettingsWindowController(
@@ -90,6 +91,7 @@ class AppDelegate: NSObject, NSApplicationDelegate,
     // Activation policy is managed solely by the Settings window
 
     registerGlobalShortcuts()
+    installEventMonitor()
   }
 
   func activate() {
@@ -131,7 +133,30 @@ class AppDelegate: NSObject, NSApplicationDelegate,
     }
   }
 
+  func installEventMonitor() {
+    // Install local event monitor to intercept modifier key combinations
+    eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+      guard let self = self else { return event }
+
+      // Only intercept when Leader Key window is key (actively receiving input)
+      guard self.controller.window.isKeyWindow else { return event }
+
+      // Check if we should hijack this event
+      if self.controller.shouldHijackEvent(event) {
+        // Pass the event to the controller and consume it
+        self.controller.keyDown(with: event)
+        return nil  // Returning nil prevents the event from being processed further
+      }
+
+      return event  // Allow normal processing
+    }
+  }
+
   func applicationWillTerminate(_ notification: Notification) {
+    // Clean up event monitor
+    if let monitor = eventMonitor {
+      NSEvent.removeMonitor(monitor)
+    }
     // Config saves automatically on changes
   }
 

--- a/Leader Key/Controller.swift
+++ b/Leader Key/Controller.swift
@@ -325,6 +325,16 @@ class Controller {
     userState.clear()
   }
 
+  func shouldHijackEvent(_ event: NSEvent) -> Bool {
+    let hijackControl = Defaults[.hijackControl]
+    let hijackOption = Defaults[.hijackOption]
+
+    let shouldHijackControl = event.modifierFlags.contains(.control) && hijackControl
+    let shouldHijackOption = event.modifierFlags.contains(.option) && hijackOption
+
+    return shouldHijackControl || shouldHijackOption
+  }
+
   private func openURL(_ action: Action) {
     guard let url = URL(string: action.value) else {
       showAlert(

--- a/Leader Key/Defaults.swift
+++ b/Leader Key/Defaults.swift
@@ -15,6 +15,10 @@ extension Defaults.Keys {
     "forceEnglishKeyboardLayout", default: false, suite: defaultsSuite)
   static let modifierKeyConfiguration = Key<ModifierKeyConfig>(
     "modifierKeyConfiguration", default: .controlGroupOptionSticky, suite: defaultsSuite)
+  static let hijackControl = Key<Bool>(
+    "hijackControl", default: false, suite: defaultsSuite)
+  static let hijackOption = Key<Bool>(
+    "hijackOption", default: false, suite: defaultsSuite)
   static let theme = Key<Theme>(
     "theme", default: .mysteryBox, suite: defaultsSuite)
 

--- a/Leader Key/Settings/AdvancedPane.swift
+++ b/Leader Key/Settings/AdvancedPane.swift
@@ -11,6 +11,8 @@ struct AdvancedPane: View {
 
   @Default(.configDir) var configDir
   @Default(.modifierKeyConfiguration) var modifierKeyConfiguration
+  @Default(.hijackControl) var hijackControl
+  @Default(.hijackOption) var hijackOption
   @Default(.autoOpenCheatsheet) var autoOpenCheatsheet
   @Default(.cheatsheetDelayMS) var cheatsheetDelayMS
   @Default(.reactivateBehavior) var reactivateBehavior
@@ -79,6 +81,25 @@ struct AdvancedPane: View {
           }
         }
         .padding(.top, 2)
+      }
+
+      Settings.Section(
+        title: "Hijack Modifier Keys", bottomDivider: true
+      ) {
+        VStack(alignment: .leading, spacing: 12) {
+          Text(
+            "When enabled, Leader Key will capture modifier key combinations early, preventing macOS from intercepting them for global shortcuts."
+          )
+          .font(.callout)
+          .foregroundColor(.secondary)
+          .fixedSize(horizontal: false, vertical: true)
+
+          HStack(spacing: 24) {
+            Toggle("Control (⌃)", isOn: $hijackControl)
+            Toggle("Option (⌥)", isOn: $hijackOption)
+            Spacer()
+          }
+        }
       }
 
       Settings.Section(title: "Cheatsheet", bottomDivider: true) {

--- a/Leader KeyTests/KeyboardLayoutTests.swift
+++ b/Leader KeyTests/KeyboardLayoutTests.swift
@@ -4,6 +4,25 @@ import XCTest
 
 @testable import Leader_Key
 
+/// Helper to create fake NSEvent for testing
+func fakeEvent(
+  keyCode: UInt16, characters: String, charactersIgnoringModifiers: String,
+  modifierFlags: NSEvent.ModifierFlags = []
+) -> NSEvent {
+  return NSEvent.keyEvent(
+    with: .keyDown,
+    location: NSPoint.zero,
+    modifierFlags: modifierFlags,
+    timestamp: 0,
+    windowNumber: 0,
+    context: nil,
+    characters: characters,
+    charactersIgnoringModifiers: charactersIgnoringModifiers,
+    isARepeat: false,
+    keyCode: keyCode
+  )!
+}
+
 class KeyboardLayoutTests: XCTestCase {
   var controller: Controller!
   var cancellables: Set<AnyCancellable>!
@@ -29,27 +48,6 @@ class KeyboardLayoutTests: XCTestCase {
     userState = nil
     userConfig = nil
     super.tearDown()
-  }
-
-  // Helper to create fake NSEvent for testing
-  private func fakeEvent(
-    keyCode: UInt16, characters: String, charactersIgnoringModifiers: String,
-    modifierFlags: NSEvent.ModifierFlags = []
-  ) -> NSEvent {
-    // This is a simplified mock - in real implementation we'd need to create a proper NSEvent
-    // For now, we'll test the logic indirectly through Controller methods
-    return NSEvent.keyEvent(
-      with: .keyDown,
-      location: NSPoint.zero,
-      modifierFlags: modifierFlags,
-      timestamp: 0,
-      windowNumber: 0,
-      context: nil,
-      characters: characters,
-      charactersIgnoringModifiers: charactersIgnoringModifiers,
-      isARepeat: false,
-      keyCode: keyCode
-    )!
   }
 
   func testAZERTYLayoutWithForceEnglishDisabled() {

--- a/Leader KeyTests/ModifierHijackingTests.swift
+++ b/Leader KeyTests/ModifierHijackingTests.swift
@@ -1,0 +1,234 @@
+import Combine
+import Defaults
+import XCTest
+
+@testable import Leader_Key
+
+// Note: fakeEvent helper is defined in KeyboardLayoutTests.swift
+// and is accessible from this file since they're in the same test target
+
+class ModifierHijackingTests: XCTestCase {
+  var controller: Controller!
+  var cancellables: Set<AnyCancellable>!
+  var userState: UserState!
+  var userConfig: UserConfig!
+  var originalHijackControl: Bool!
+  var originalHijackOption: Bool!
+
+  override func setUp() {
+    super.setUp()
+
+    originalHijackControl = Defaults[.hijackControl]
+    originalHijackOption = Defaults[.hijackOption]
+
+    cancellables = Set<AnyCancellable>()
+
+    // Create test instances
+    userConfig = UserConfig()
+    userState = UserState(userConfig: userConfig)
+    controller = Controller(userState: userState, userConfig: userConfig)
+  }
+
+  override func tearDown() {
+    Defaults[.hijackControl] = originalHijackControl
+    Defaults[.hijackOption] = originalHijackOption
+    cancellables = nil
+    controller = nil
+    userState = nil
+    userConfig = nil
+    super.tearDown()
+  }
+
+  // MARK: - Defaults Tests
+
+  func testHijackControlDefaultsToFalse() {
+    XCTAssertFalse(Defaults[.hijackControl], "hijackControl should default to false")
+  }
+
+  func testHijackOptionDefaultsToFalse() {
+    XCTAssertFalse(Defaults[.hijackOption], "hijackOption should default to false")
+  }
+
+  // MARK: - Settings Tests
+
+  func testHijackControlSettingCanBeEnabled() {
+    Defaults[.hijackControl] = true
+    XCTAssertTrue(Defaults[.hijackControl], "hijackControl should be enabled")
+  }
+
+  func testHijackControlSettingCanBeDisabled() {
+    Defaults[.hijackControl] = true
+    Defaults[.hijackControl] = false
+    XCTAssertFalse(Defaults[.hijackControl], "hijackControl should be disabled")
+  }
+
+  func testHijackOptionSettingCanBeEnabled() {
+    Defaults[.hijackOption] = true
+    XCTAssertTrue(Defaults[.hijackOption], "hijackOption should be enabled")
+  }
+
+  func testHijackOptionSettingCanBeDisabled() {
+    Defaults[.hijackOption] = true
+    Defaults[.hijackOption] = false
+    XCTAssertFalse(Defaults[.hijackOption], "hijackOption should be disabled")
+  }
+
+  func testControlAndOptionCanBothBeEnabled() {
+    Defaults[.hijackControl] = true
+    Defaults[.hijackOption] = true
+
+    XCTAssertTrue(Defaults[.hijackControl], "hijackControl should be enabled")
+    XCTAssertTrue(Defaults[.hijackOption], "hijackOption should be enabled")
+  }
+
+  // MARK: - Modifier Key Configuration Interaction Tests
+
+  func testHijackingDoesNotAffectModifierKeyConfiguration() {
+    // Set modifier key configuration
+    Defaults[.modifierKeyConfiguration] = .controlGroupOptionSticky
+
+    // Enable hijacking
+    Defaults[.hijackControl] = true
+    Defaults[.hijackOption] = true
+
+    // Verify modifier key configuration is unchanged
+    XCTAssertEqual(
+      Defaults[.modifierKeyConfiguration],
+      .controlGroupOptionSticky,
+      "Modifier key configuration should remain unchanged"
+    )
+  }
+
+  func testModifierKeyConfigurationDoesNotAffectHijacking() {
+    // Enable hijacking
+    Defaults[.hijackControl] = true
+    Defaults[.hijackOption] = true
+
+    // Change modifier key configuration
+    Defaults[.modifierKeyConfiguration] = .optionGroupControlSticky
+
+    // Verify hijacking settings are unchanged
+    XCTAssertTrue(
+      Defaults[.hijackControl],
+      "hijackControl should remain enabled")
+    XCTAssertTrue(
+      Defaults[.hijackOption],
+      "hijackOption should remain enabled")
+  }
+
+  // MARK: - shouldHijackEvent Tests
+
+  func testShouldHijackEventWithControlAndHijackEnabled() {
+    Defaults[.hijackControl] = true
+
+    let ctrlEvent = fakeEvent(
+      keyCode: KeyHelpers.tab.rawValue,
+      characters: "\t",
+      charactersIgnoringModifiers: "\t",
+      modifierFlags: .control
+    )
+
+    XCTAssertTrue(
+      controller.shouldHijackEvent(ctrlEvent),
+      "Should hijack event when Control is pressed and hijackControl is enabled"
+    )
+  }
+
+  func testShouldNotHijackEventWithControlAndHijackDisabled() {
+    Defaults[.hijackControl] = false
+
+    let ctrlEvent = fakeEvent(
+      keyCode: KeyHelpers.tab.rawValue,
+      characters: "\t",
+      charactersIgnoringModifiers: "\t",
+      modifierFlags: .control
+    )
+
+    XCTAssertFalse(
+      controller.shouldHijackEvent(ctrlEvent),
+      "Should not hijack event when Control is pressed but hijackControl is disabled"
+    )
+  }
+
+  func testShouldHijackEventWithOptionAndHijackEnabled() {
+    Defaults[.hijackOption] = true
+
+    let optEvent = fakeEvent(
+      keyCode: KeyHelpers.tab.rawValue,
+      characters: "\t",
+      charactersIgnoringModifiers: "\t",
+      modifierFlags: .option
+    )
+
+    XCTAssertTrue(
+      controller.shouldHijackEvent(optEvent),
+      "Should hijack event when Option is pressed and hijackOption is enabled"
+    )
+  }
+
+  func testShouldNotHijackEventWithOptionAndHijackDisabled() {
+    Defaults[.hijackOption] = false
+
+    let optEvent = fakeEvent(
+      keyCode: KeyHelpers.tab.rawValue,
+      characters: "\t",
+      charactersIgnoringModifiers: "\t",
+      modifierFlags: .option
+    )
+
+    XCTAssertFalse(
+      controller.shouldHijackEvent(optEvent),
+      "Should not hijack event when Option is pressed but hijackOption is disabled"
+    )
+  }
+
+  func testShouldHijackEventWithBothModifiersAndControlHijackEnabled() {
+    Defaults[.hijackControl] = true
+    Defaults[.hijackOption] = false
+
+    let bothEvent = fakeEvent(
+      keyCode: KeyHelpers.tab.rawValue,
+      characters: "\t",
+      charactersIgnoringModifiers: "\t",
+      modifierFlags: [.control, .option]
+    )
+
+    XCTAssertTrue(
+      controller.shouldHijackEvent(bothEvent),
+      "Should hijack event when both modifiers are pressed and hijackControl is enabled"
+    )
+  }
+
+  func testShouldNotHijackEventWithNoModifiers() {
+    Defaults[.hijackControl] = true
+    Defaults[.hijackOption] = true
+
+    let noModEvent = fakeEvent(
+      keyCode: KeyHelpers.tab.rawValue,
+      characters: "\t",
+      charactersIgnoringModifiers: "\t"
+    )
+
+    XCTAssertFalse(
+      controller.shouldHijackEvent(noModEvent),
+      "Should not hijack event when no modifiers are pressed"
+    )
+  }
+
+  func testShouldNotHijackEventWithCommandModifier() {
+    Defaults[.hijackControl] = true
+    Defaults[.hijackOption] = true
+
+    let cmdEvent = fakeEvent(
+      keyCode: KeyHelpers.tab.rawValue,
+      characters: "\t",
+      charactersIgnoringModifiers: "\t",
+      modifierFlags: .command
+    )
+
+    XCTAssertFalse(
+      controller.shouldHijackEvent(cmdEvent),
+      "Should not hijack event when only Command is pressed"
+    )
+  }
+}


### PR DESCRIPTION
This adds settings to allow Leader Key to hijack OPT and CTRL keys before macOS checks for global shortcuts.

I have a setup where I'm using CTRL as the sticky key, and a shortcut that is TAB. The combination CTRL-TAB is picked up by macOS and never delivered to Leader Key.

Two new settings are on the Advanced tab.

<img width="627" height="103" alt="Screenshot 2026-01-16 at 13 24 04" src="https://github.com/user-attachments/assets/e989fa80-dbc5-4d0b-96bc-1f94530e1c63" />
