### PR TITLE
tests: prevent UserConfigTests from touching real user config directory

### DIFF
--- a/Leader Key/UserConfig.swift
+++ b/Leader Key/UserConfig.swift
@@ -20,6 +20,7 @@ class UserConfig: ObservableObject {
   let fileName = "config.json"
   private let alertHandler: AlertHandler
   private let fileManager: FileManager
+  private let defaultDirectoryResolver: () -> String
   private var lastReadChecksum: String?
   private var isLoading = false
   private let configIOQueue = DispatchQueue(label: "ConfigIO", qos: .userInitiated)
@@ -27,10 +28,12 @@ class UserConfig: ObservableObject {
 
   init(
     alertHandler: AlertHandler = DefaultAlertHandler(),
-    fileManager: FileManager = .default
+    fileManager: FileManager = .default,
+    defaultDirectoryResolver: @escaping () -> String = UserConfig.defaultDirectory
   ) {
     self.alertHandler = alertHandler
     self.fileManager = fileManager
+    self.defaultDirectoryResolver = defaultDirectoryResolver
   }
 
   // MARK: - Public Interface
@@ -194,7 +197,7 @@ class UserConfig: ObservableObject {
 
   private func ensureValidConfigDirectory() {
     let dir = Defaults[.configDir]
-    let defaultDir = Self.defaultDirectory()
+    let defaultDir = defaultDirectoryResolver()
 
     if !fileManager.fileExists(atPath: dir) {
       alertHandler.showAlert(

--- a/Leader KeyTests/UserConfigTests.swift
+++ b/Leader KeyTests/UserConfigTests.swift
@@ -24,6 +24,7 @@ class TestAlertManager: AlertHandler {
 
 final class UserConfigTests: XCTestCase {
   var tempBaseDir: String!
+  var testDefaultDir: String!
   var testAlertManager: TestAlertManager!
   var subject: UserConfig!
   var originalSuite: UserDefaults!
@@ -38,12 +39,21 @@ final class UserConfigTests: XCTestCase {
     // Create a unique temporary directory for each test
     tempBaseDir = NSTemporaryDirectory().appending("/LeaderKeyTests-\(UUID().uuidString)")
     try? FileManager.default.createDirectory(atPath: tempBaseDir, withIntermediateDirectories: true)
+    testDefaultDir = tempBaseDir.appending("/DefaultConfigDir")
+
+    // Point config dir at temp location before creating UserConfig.
+    Defaults[.configDir] = tempBaseDir
 
     testAlertManager = TestAlertManager()
-    subject = UserConfig(alertHandler: testAlertManager)
-
-    // Set the config directory to our temp directory by default
-    Defaults[.configDir] = tempBaseDir
+    let isolatedDefaultDir = testDefaultDir!
+    subject = UserConfig(
+      alertHandler: testAlertManager,
+      defaultDirectoryResolver: {
+        try? FileManager.default.createDirectory(
+          atPath: isolatedDefaultDir, withIntermediateDirectories: true)
+        return isolatedDefaultDir
+      }
+    )
   }
 
   override func tearDown() {
@@ -67,7 +77,7 @@ final class UserConfigTests: XCTestCase {
   }
 
   func testCreatesDefaultConfigDirIfNotExists() throws {
-    let defaultDir = UserConfig.defaultDirectory()
+    let defaultDir = testDefaultDir!
     // Remove both directory and config file
     try? FileManager.default.removeItem(atPath: defaultDir)
     try? FileManager.default.removeItem(
@@ -90,7 +100,7 @@ final class UserConfigTests: XCTestCase {
     subject.ensureAndLoad()
     waitForConfigLoad()
 
-    XCTAssertEqual(Defaults[.configDir], UserConfig.defaultDirectory())
+    XCTAssertEqual(Defaults[.configDir], testDefaultDir)
     XCTAssertEqual(testAlertManager.shownAlerts.count, 1)
     XCTAssertEqual(testAlertManager.shownAlerts[0].style, .warning)
     XCTAssertTrue(
@@ -99,8 +109,10 @@ final class UserConfigTests: XCTestCase {
   }
 
   func testShowsAlertWhenConfigFileFailsToParse() throws {
-    // First ensure we're in the default directory since custom dirs are no longer supported
-    Defaults[.configDir] = UserConfig.defaultDirectory()
+    // Ensure we're exercising the default directory path (isolated under tempBaseDir).
+    Defaults[.configDir] = testDefaultDir
+    try? FileManager.default.createDirectory(
+      atPath: testDefaultDir, withIntermediateDirectories: true)
 
     let invalidJSON = "{ invalid json }"
     try invalidJSON.write(to: subject.url, atomically: true, encoding: .utf8)


### PR DESCRIPTION
## Summary

This PR fixes a high-severity test isolation bug where `UserConfigTests` could read/write/delete files in the real user config location (`~/Library/Application Support/Leader Key`).

Some tests exercised the “default config directory” path and could remove that directory or write invalid JSON into the live `config.json` during normal `xcodebuild test` runs.

## Root Cause

`UserConfigTests` used real default-directory resolution when validating fallback behavior. That allowed test file operations to target real user data.

## Changes

### 1) Add a narrow injection seam for default directory resolution
- `Leader Key/UserConfig.swift`
- `UserConfig` now accepts an init parameter:
  - `defaultDirectoryResolver: @escaping () -> String = UserConfig.defaultDirectory`
- `ensureValidConfigDirectory()` now uses this resolver.
- Runtime behavior is unchanged because production code uses the default resolver.

### 2) Fully isolate `UserConfigTests`
- `Leader KeyTests/UserConfigTests.swift`
- In `setUp`, tests now provide an isolated temp default directory via the new init resolver.
- Tests no longer call real-path default resolution when validating fallback/parse-error behavior.
- Assertions were updated accordingly.

## Safety / Compatibility

- No config format changes.
- No migration needed.
- No user-facing behavior changes expected.

## Validation

- `xcodebuild -scheme 'Leader Key' -skipPackagePluginValidation CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO test`
- `xcodebuild -scheme 'Leader Key' -configuration Release -skipPackagePluginValidation CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build`

Both succeeded.

Additionally verified manually that the real config file hash at `~/Library/Application Support/Leader Key/config.json` stayed unchanged before/after test and build runs.

## Why this should merge quickly

- Small, focused diff (2 files).
- Addresses user-data safety risk in test runs.
- Keeps production behavior unchanged.
